### PR TITLE
Add supported environment for iOS12

### DIFF
--- a/pages/katalon-studio/docs/supported-environments.md
+++ b/pages/katalon-studio/docs/supported-environments.md
@@ -27,6 +27,8 @@ Mobile
 | Installation | Version on Windows | Version on macOS | Appium | Native App support? | Hybrid App support?(*) | Mobile Browser support? |
 | --- | --- | --- | --- | --- | --- | --- |
 | Android | 6.x, 7.x | 6.x, 7.x | 1.6, 1.7, 1.8 | YES | NO | YES |
-| iOS | Not Available | 9, 10, 11 | 1.6, 1.7, 1.8 | YES | NO | YES |
+| iOS | Not Available | 9, 10, 11, 12** | 1.6, 1.7, 1.8 | YES | NO | YES |
 
 (*): You can use supported [functions](http://appium.io/docs/en/writing-running-appium/web/hybrid/#automating-hybrid-apps) from Appium to handle it by yourself
+
+(**): With Appium 1.8.2-beta only


### PR DESCRIPTION
We can now use Katalon Studio with Xcode10 and iOS12 devices and Appium 1.8.2-beta.