### PR TITLE
Update installing-webdriveragent-for-ios-devices.md

### DIFF
--- a/pages/katalon-studio/docs/installing-webdriveragent-for-ios-devices.md
+++ b/pages/katalon-studio/docs/installing-webdriveragent-for-ios-devices.md
@@ -90,7 +90,7 @@ sh ./Scripts/bootstrap.sh -d
     ```groovy
     export DEVICE_URL='http://<device IP>:8100'
     export JSON_HEADER='-H "Content-Type: application/json;charset=UTF-8, accept:application/json"'
-    curl -X GET $JSON_HEADER $DEVICE_URL/status
+    curl -X GET '$JSON_HEADER' $DEVICE_URL/status
     ```
 
     ```groovy


### PR DESCRIPTION
If we don't enclose the values in quotes, when running:

`curl -X GET $JSON_HEADER $DEVICE_URL/status`

we'll get some misleading message like:

```
curl: (6) Could not resolve host: application
curl: (3) Port number ended with 'a'
```