### PR TITLE
Update details release note 630

### DIFF
--- a/pages/katalon-studio/new/version-630.md
+++ b/pages/katalon-studio/new/version-630.md
@@ -20,12 +20,12 @@ Click [Katalon Studio 6.3.0 (Beta)](https://github.com/katalon-studio/katalon-st
 ### Improvements
 
 *   Support Dark theme in addition to the default Light theme. See [Using Katalon Studio in Dark theme](https://docs.katalon.com/katalon-studio/docs/dark-theme.html).
-*   Allow Test Reports to be viewed directly in Test Suite and Test Suite Collection Views in Result Tab.
+*   Allow Test Reports to be viewed directly in Test Suite and Test Suite Collection Views in Result Tab. See [Test Suite Report](https://docs.katalon.com/katalon-studio/docs/test-suite-report.html) or [Test Suite Collection Report](https://docs.katalon.com/katalon-studio/docs/test-suite-collection-report.html).
 *   Support sending custom headers in SOAP requests.
-*   Directly parameterize Global variables in Test Objects. See [Global Variables](https://docs.katalon.com/katalon-studio/docs/global-variables.html)
+*   Directly parameterize Global variables in Test Objects. See [Global Variables](https://docs.katalon.com/katalon-studio/docs/global-variables.html).
 *   Allow implementing variable binding without converting test data to strings. See [Enhanced Variable Binding](https://docs.katalon.com/katalon-studio/docs/bind-as-string.html#variable-binding-for-test-data-with-option-embind-into-test-case-as-stringem-enabled).
-*   Support implementing an annotation called BeforeTestDataBindToTestCase in test listener.
-*   Support Move up and Move down items in the default profile.
+*   Support implementing an annotation called BeforeTestDataBindToTestCase in test listener. See [[Quick tip] Enhanced Variable Binding](https://docs.katalon.com/katalon-studio/docs/bind-as-string.html).
+*   Support Move up and Move down items in the default profile. See [Global Variables](https://docs.katalon.com/katalon-studio/docs/global-variables.html).
 *   Support spying, recording and running the Mobile script on custom cloud-based testing tools.  See [Testing Mobile Apps Using Custom Cloud Devices](/katalon-studio/docs/mobile-testing-apps-cloud-devices.html).
 *   Support spying, recording and running existing applications on Android and iOS devices. See [[Mobile] Start Existing Application](/katalon-studio/docs/mobile-keyword-start-existing-apps.html) and [Spy and Record Utilities for testing an existing application](/katalon-studio/docs/mobile-spy-record-existing-apps.html).
-*   Support quickly setting up your devices by displaying sub-menus of Android, iOS and Kobiton devices in Mobile Spy and Recorder tool items.
+*   Support quickly setting up your devices by displaying sub-menus of Android, iOS and Kobiton devices in Mobile Spy and Recorder tool items. 


### PR DESCRIPTION
Add details for:
- Allow Test Reports to be viewed directly in Test Suite and Test Suite Collection Views in Result Tab. Resolve #404 
- Allow implementing variable binding without converting test data to strings. Resolve #401 
- Support implementing an annotation called BeforeTestDataBindToTestCase in test listener. Resolve #398 
- Support Move up and Move down items in the default profile. Resolve #407 