### PR TITLE
update exit code

### DIFF
--- a/pages/katalon-studio/docs/console-mode-execution.md
+++ b/pages/katalon-studio/docs/console-mode-execution.md
@@ -46,11 +46,20 @@ Execute Katalon in CMD
 
 
 3.  Press **Enter** to start execution.
+4.  **Exit Code**
+
+      Below is the list of exit codes after console mode execution:
+
+   *   0: the execution passed with no failed or error test case.
+   *   1: the execution has failed test cases.
+   *   2: the execution has error test cases.
+   *   3: the execution has failed test cases and error test cases.
+   *   4: the execution cannot start because of invalid arguments.
 
 Katalon Studio Plugins in Console Mode
 --------------------------------------
 
-To use in console mode, Katalon Studio Plugins must be installed using Katalon Store's API keys. Please follow instructions [here](/katalon-store/docs/user/plugin-console-installation.html).
+> To use in console mode, Katalon Studio Plugins must be installed using Katalon Store's API keys. Please follow instructions [here](/katalon-store/docs/user/plugin-console-installation.html).
 
 General Options 
 ---------------

--- a/pages/katalon-studio/docs/jenkins-integration.md
+++ b/pages/katalon-studio/docs/jenkins-integration.md
@@ -79,14 +79,6 @@ Exit Codes
 When you execute Katalon Studio command from CI , exit code will be generated as the output of your execution. You can use this exit code to know whether your execution is successful, passed or failed.
 ![](https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/jenkins-integration/image2016-9-8-103A433A50.png)
 
-Below is the list of exit codes after console mode execution:
-
-*   0: the execution passed with no failed or error test case.
-*   1: the execution has failed test cases.
-*   2: the execution has error test cases.
-*   3: the execution has failed test cases and error test cases.
-*   4: the execution cannot start because of invalid arguments.
-
 Publish JUnit reports
 ---------------------
 


### PR DESCRIPTION
- [x] Moving "Exit Code" from https://docs.katalon.com/katalon-studio/docs/jenkins-integration.html#exit-codes to https://docs.katalon.com/katalon-studio/docs/console-mode-execution.html
- [x] highlight "To use in console mode, Katalon Studio Plugins must be installed using Katalon Store's API keys. Please follow instructions here."