### PR TITLE
STUDIO-288 Web new take screenshot keyword

### DIFF
--- a/pages/katalon-studio/docs/webui-take-area-screenshot-as-checkpoint.md
+++ b/pages/katalon-studio/docs/webui-take-area-screenshot-as-checkpoint.md
@@ -1,0 +1,56 @@
+---
+
+title: "[WebUI] Take Area Screenshot As Checkpoint"
+
+sidebar: katalon_studio_docs_sidebar
+
+permalink: katalon-studio/docs/webui-take-area-screeenshot-as-checkpoint.html
+
+---
+
+> From version **7.7.0**, this keyword is available.
+
+  
+
+## takeAreaScreenshotAsCheckpoint
+
+  
+
+*  **Description**: Take screenshot of a specific area in the viewport to send to TestOps Vision. The captured image will be saved in '.png' format and stored in 'keyes' folder in report folder.
+
+*  **Keyword name**: takeAreaScreenshotAsCheckpoint
+
+*  **Keyword syntax**: WebUI.takeAreaScreenshotAsCheckpoint(checkpointName, rect, flowControl)
+
+*  **Parameters**:
+   * Name: checkpointName 
+
+     * Description: A String that represents the name of the image on TestOps Vision. On local machine this name will be appended with TestOps Vision prefix('keyes-').
+
+     * Parameter Type: String
+
+     * Mandatory: Required
+     
+    * Name: rect
+	    * Description: An Rectangle which defines location and size of the area you want to take screenshot. The area must be within the viewport.
+
+       * Parameter Type: Rectangle
+
+       * Mandatory: Required
+
+   * Name: flowControl
+
+     * Description: Specify [failure handling](/x/qAAM) schema to determine whether the execution should be allowed to continue or stop.
+
+     * Parameter Type: FailureHandling
+
+     * Mandatory: Optional
+
+* **Examples**:
+
+1. You want to take TestOps Vision screenshot of an area at x: 50, y: 25, width: 100, height: 150 :
+``` groovy
+import org.openqa.selenium.Rectangle as Rectangle
+
+WebUI.takeAreaScreenshotAsCheckpoint('advertisements', new Rectangle(50, 25, 100, 150))
+```

--- a/pages/katalon-studio/docs/webui-take-area-screenshot-as-checkpoint.md
+++ b/pages/katalon-studio/docs/webui-take-area-screenshot-as-checkpoint.md
@@ -8,13 +8,13 @@ permalink: katalon-studio/docs/webui-take-area-screenshot-as-checkpoint.html
 
 ## takeAreaScreenshotAsCheckpoint
 
-*  **Description**: Take screenshot of a specific area in the viewport to send to TestOps Vision. The captured image will be saved in '.png' format and stored in 'keyes' folder in report folder.
+*  **Description**: Take a screenshot of a specific area in the viewport to send to TestOps Vision. The captured image will be saved in '.png' format and stored in the 'keyes' folder in the report folder.
 *  **Keyword name**: takeAreaScreenshotAsCheckpoint
 *  **Keyword syntax**: `WebUI.takeAreaScreenshotAsCheckpoint(checkpointName, rect, flowControl)`
 *  **Parameters**:
 
    * Name: checkpointName 
-     * Description: A String that represents the name of the image on TestOps Vision. On local machine this name will be appended with TestOps Vision prefix('keyes-').
+     * Description: A String that represents the name of the image on TestOps Vision. On a local machine, this name will be appended with TestOps Vision prefix('keyes-').
      * Parameter Type: String
      * Mandatory: Required
      

--- a/pages/katalon-studio/docs/webui-take-area-screenshot-as-checkpoint.md
+++ b/pages/katalon-studio/docs/webui-take-area-screenshot-as-checkpoint.md
@@ -1,54 +1,37 @@
 ---
-
 title: "[WebUI] Take Area Screenshot As Checkpoint"
-
 sidebar: katalon_studio_docs_sidebar
-
 permalink: katalon-studio/docs/webui-take-area-screenshot-as-checkpoint.html
-
 ---
 
 > From version **7.7.0**, this keyword is available.
 
-  
-
 ## takeAreaScreenshotAsCheckpoint
 
-  
-
 *  **Description**: Take screenshot of a specific area in the viewport to send to TestOps Vision. The captured image will be saved in '.png' format and stored in 'keyes' folder in report folder.
-
 *  **Keyword name**: takeAreaScreenshotAsCheckpoint
-
-*  **Keyword syntax**: WebUI.takeAreaScreenshotAsCheckpoint(checkpointName, rect, flowControl)
-
+*  **Keyword syntax**: `WebUI.takeAreaScreenshotAsCheckpoint(checkpointName, rect, flowControl)`
 *  **Parameters**:
+
    * Name: checkpointName 
-
      * Description: A String that represents the name of the image on TestOps Vision. On local machine this name will be appended with TestOps Vision prefix('keyes-').
-
      * Parameter Type: String
-
      * Mandatory: Required
      
-    * Name: rect
-	    * Description: A Rectangle which defines location and size of the area you want to take screenshot. The area must be within the viewport.
-
-       * Parameter Type: Rectangle
-
-       * Mandatory: Required
+   * Name: rect
+     * Description: A Rectangle which defines location and size of the area you want to take screenshot. The area must be within the viewport.
+     * Parameter Type: Rectangle
+     * Mandatory: Required
 
    * Name: flowControl
-
      * Description: Specify [failure handling](/x/qAAM) schema to determine whether the execution should be allowed to continue or stop.
-
      * Parameter Type: FailureHandling
-
      * Mandatory: Optional
 
 * **Examples**:
 
 You want to take TestOps Vision screenshot of an area at x: 50, y: 25, width: 100, height: 150 :
+
 ``` groovy
 import org.openqa.selenium.Rectangle as Rectangle
 

--- a/pages/katalon-studio/docs/webui-take-area-screenshot-as-checkpoint.md
+++ b/pages/katalon-studio/docs/webui-take-area-screenshot-as-checkpoint.md
@@ -4,7 +4,7 @@ title: "[WebUI] Take Area Screenshot As Checkpoint"
 
 sidebar: katalon_studio_docs_sidebar
 
-permalink: katalon-studio/docs/webui-take-area-screeenshot-as-checkpoint.html
+permalink: katalon-studio/docs/webui-take-area-screenshot-as-checkpoint.html
 
 ---
 
@@ -32,7 +32,7 @@ permalink: katalon-studio/docs/webui-take-area-screeenshot-as-checkpoint.html
      * Mandatory: Required
      
     * Name: rect
-	    * Description: An Rectangle which defines location and size of the area you want to take screenshot. The area must be within the viewport.
+	    * Description: A Rectangle which defines location and size of the area you want to take screenshot. The area must be within the viewport.
 
        * Parameter Type: Rectangle
 
@@ -48,9 +48,9 @@ permalink: katalon-studio/docs/webui-take-area-screeenshot-as-checkpoint.html
 
 * **Examples**:
 
-1. You want to take TestOps Vision screenshot of an area at x: 50, y: 25, width: 100, height: 150 :
+You want to take TestOps Vision screenshot of an area at x: 50, y: 25, width: 100, height: 150 :
 ``` groovy
 import org.openqa.selenium.Rectangle as Rectangle
 
-WebUI.takeAreaScreenshotAsCheckpoint('advertisements', new Rectangle(50, 25, 100, 150))
+WebUI.takeAreaScreenshotAsCheckpoint('advertisements', new Rectangle(50, 25, 150, 100))
 ```

--- a/pages/katalon-studio/docs/webui-take-area-screenshot.md
+++ b/pages/katalon-studio/docs/webui-take-area-screenshot.md
@@ -1,0 +1,70 @@
+---
+
+title: "[WebUI] Take Area Screenshot"
+
+sidebar: katalon_studio_docs_sidebar
+
+permalink: katalon-studio/docs/webui-take-area-screeenshot.html
+
+---
+
+> From version **7.7.0**, this keyword is available.
+
+  
+
+## takeAreaScreenshot
+
+  
+
+*  **Description**: Take screenshot of a specific area in the viewport. The captured image will be saved in '.png' format.
+
+*  **Keyword name**: takeAreaScreenshotAs
+
+*  **Keyword syntax**: WebUI.takeAreaScreenshot(fileName, rect, flowControl)
+
+*  **Parameters**:
+   * Name: fileName 
+
+     * Description: A String that represents the path to the saved image. The path can be absolute path or relative path.
+
+     * Parameter Type: String
+
+     * Mandatory: Optinal
+     
+    * Name: rect
+	    * Description: An Rectangle which defines location and size of the area you want to take screenshot. The area must be within the viewport.
+
+       * Parameter Type: Rectangle
+
+       * Mandatory: Required
+
+   * Name: flowControl
+
+     * Description: Specify [failure handling](/x/qAAM) schema to determine whether the execution should be allowed to continue or stop.
+
+     * Parameter Type: FailureHandling
+
+     * Mandatory: Optional
+
+* **Examples**:
+
+1. You want to take screenshot of an area at x: 50, y: 25, width: 100, height: 150 and save to file 'advertisements.png' in report folder of current project:
+``` groovy
+import org.openqa.selenium.Rectangle as Rectangle
+import com.kms.katalon.core.configuration.RunConfiguration as RunConfiguration
+
+WebUI.takeAreaScreenshot(RunConfiguration.getReportFolder() + '/advertisements.png', new Rectangle(50, 25, 100, 150))
+```
+2. You want to take screenshot of an area at x: 50, y: 25, width: 100, height: 150 and use default filename:
+``` groovy
+import org.openqa.selenium.Rectangle as Rectangle
+
+WebUI.takeAreaScreenshot(new Rectangle(50, 25, 100, 150))
+```
+
+2. You want to take screenshot of an area at x: 50, y: 25, width: 100, height: 150 and save to somewhere else:
+``` groovy
+import org.openqa.selenium.Rectangle as Rectangle
+
+WebUI.takeAreaScreenshot('E:\\area.png', new Rectangle(50, 25, 100, 150))
+```

--- a/pages/katalon-studio/docs/webui-take-area-screenshot.md
+++ b/pages/katalon-studio/docs/webui-take-area-screenshot.md
@@ -1,68 +1,54 @@
 ---
-
 title: "[WebUI] Take Area Screenshot"
-
 sidebar: katalon_studio_docs_sidebar
-
 permalink: katalon-studio/docs/webui-take-area-screenshot.html
-
 ---
 
 > From version **7.7.0**, this keyword is available.
-
   
-
-## takeAreaScreenshot
-
-  
+## takeAreaScreenshot  
 
 *  **Description**: Take screenshot of a specific area in the viewport. The captured image will be saved in '.png' format.
-
 *  **Keyword name**: takeAreaScreenshot
-
-*  **Keyword syntax**: WebUI.takeAreaScreenshot(fileName, rect, flowControl)
-
+*  **Keyword syntax**: `WebUI.takeAreaScreenshot(fileName, rect, flowControl)`
 *  **Parameters**:
+
    * Name: fileName 
-
      * Description: A String that represents the path to the saved image. The path can be absolute path or relative path.
-
      * Parameter Type: String
-
      * Mandatory: Optional
      
    * Name: rect
-	    * Description: A Rectangle which defines location and size of the area you want to take screenshot. The area must be within the viewport.
-
-       * Parameter Type: Rectangle
-
-       * Mandatory: Required
+     * Description: A Rectangle which defines location and size of the area you want to take screenshot. The area must be within the viewport.
+     * Parameter Type: Rectangle
+     * Mandatory: Required
 
    * Name: flowControl
-
      * Description: Specify [failure handling](/x/qAAM) schema to determine whether the execution should be allowed to continue or stop.
-
      * Parameter Type: FailureHandling
-
      * Mandatory: Optional
 
 * **Examples**:
 
-1. You want to take screenshot of an area at x: 50, y: 25, width: 100, height: 150 and save to file 'advertisements.png' in report folder of current project:
+1. You want to take a screenshot of an area at x: 50, y: 25, width: 100, height: 150 and save the 'advertisements.png' file in the current project's report folder:
+
 ``` groovy
 import org.openqa.selenium.Rectangle as Rectangle
 import com.kms.katalon.core.configuration.RunConfiguration as RunConfiguration
 
 WebUI.takeAreaScreenshot(RunConfiguration.getReportFolder() + '/advertisements.png', new Rectangle(50, 25, 100, 150))
 ```
-2. You want to take screenshot of an area at x: 50, y: 25, width: 100, height: 150 and use default filename:
+
+2. You want to take a screenshot of an area at x: 50, y: 25, width: 100, height: 150 and use the default file name:
+
 ``` groovy
 import org.openqa.selenium.Rectangle as Rectangle
 
 WebUI.takeAreaScreenshot(new Rectangle(50, 25, 150, 100))
 ```
 
-2. You want to take screenshot of an area at x: 50, y: 25, width: 100, height: 150 and save to somewhere else:
+2. You want to take a screenshot of an area at x: 50, y: 25, width: 100, height: 150 and save it somewhere else:
+
 ``` groovy
 import org.openqa.selenium.Rectangle as Rectangle
 

--- a/pages/katalon-studio/docs/webui-take-area-screenshot.md
+++ b/pages/katalon-studio/docs/webui-take-area-screenshot.md
@@ -4,7 +4,7 @@ title: "[WebUI] Take Area Screenshot"
 
 sidebar: katalon_studio_docs_sidebar
 
-permalink: katalon-studio/docs/webui-take-area-screeenshot.html
+permalink: katalon-studio/docs/webui-take-area-screenshot.html
 
 ---
 
@@ -18,7 +18,7 @@ permalink: katalon-studio/docs/webui-take-area-screeenshot.html
 
 *  **Description**: Take screenshot of a specific area in the viewport. The captured image will be saved in '.png' format.
 
-*  **Keyword name**: takeAreaScreenshotAs
+*  **Keyword name**: takeAreaScreenshot
 
 *  **Keyword syntax**: WebUI.takeAreaScreenshot(fileName, rect, flowControl)
 
@@ -29,10 +29,10 @@ permalink: katalon-studio/docs/webui-take-area-screeenshot.html
 
      * Parameter Type: String
 
-     * Mandatory: Optinal
+     * Mandatory: Optional
      
-    * Name: rect
-	    * Description: An Rectangle which defines location and size of the area you want to take screenshot. The area must be within the viewport.
+   * Name: rect
+	    * Description: A Rectangle which defines location and size of the area you want to take screenshot. The area must be within the viewport.
 
        * Parameter Type: Rectangle
 
@@ -59,12 +59,12 @@ WebUI.takeAreaScreenshot(RunConfiguration.getReportFolder() + '/advertisements.p
 ``` groovy
 import org.openqa.selenium.Rectangle as Rectangle
 
-WebUI.takeAreaScreenshot(new Rectangle(50, 25, 100, 150))
+WebUI.takeAreaScreenshot(new Rectangle(50, 25, 150, 100))
 ```
 
 2. You want to take screenshot of an area at x: 50, y: 25, width: 100, height: 150 and save to somewhere else:
 ``` groovy
 import org.openqa.selenium.Rectangle as Rectangle
 
-WebUI.takeAreaScreenshot('E:\\area.png', new Rectangle(50, 25, 100, 150))
+WebUI.takeAreaScreenshot('E:\\area.png', new Rectangle(50, 25, 150, 100))
 ```

--- a/pages/katalon-studio/docs/webui-take-element-screenshot-as-checkpoint.md
+++ b/pages/katalon-studio/docs/webui-take-element-screenshot-as-checkpoint.md
@@ -4,7 +4,7 @@ title: "[WebUI] Take Element Screenshot As Checkpoint"
 
 sidebar: katalon_studio_docs_sidebar
 
-permalink: katalon-studio/docs/webui-take-element-screeenshot-as-checkpoint.html
+permalink: katalon-studio/docs/webui-take-element-screenshot-as-checkpoint.html
 
 ---
 

--- a/pages/katalon-studio/docs/webui-take-element-screenshot-as-checkpoint.md
+++ b/pages/katalon-studio/docs/webui-take-element-screenshot-as-checkpoint.md
@@ -1,60 +1,44 @@
 ---
-
 title: "[WebUI] Take Element Screenshot As Checkpoint"
-
 sidebar: katalon_studio_docs_sidebar
-
 permalink: katalon-studio/docs/webui-take-element-screenshot-as-checkpoint.html
-
 ---
 
 > From version **7.7.0**, this keyword is available.
 
-  
-
 ## takeElementScreenshotAsCheckpoint
 
-  
-
-*  **Description**: Take screenshot of a specific web element to send to TestOps Vision. The captured image will be saved in '.png' format and stored in 'keyes' folder in report folder.
-
+*  **Description**: Take screenshot of a specific web element to send to TestOps Vision. The captured image will be saved with '.png' format and stored in the 'keyes' folder in report folder.
 *  **Keyword name**: takeElementScreenshotAsCheckpoint
-
-*  **Keyword syntax**: WebUI.takeElementScreenshotAsCheckpoint(checkpointName, to, flowControl)
-
+*  **Keyword syntax**: `WebUI.takeElementScreenshotAsCheckpoint(checkpointName, to, flowControl)`
 *  **Parameters**:
+
    * Name: checkpointName 
-
      * Description: A String that represents the name of the image on TestOps Vision. On local machine this name will be appended with TestOps Vision prefix('keyes-').
-
      * Parameter Type: String
-
      * Mandatory: Required
      
     * Name: to
-	    * Description: TestObject which represents the element you want to take screenshot.
-
+       * Description: TestObject which represents the element you want to take screenshot.
        * Parameter Type: TestObject
-
        * Mandatory: Required
 
    * Name: flowControl
-
      * Description: Specify [failure handling](/x/qAAM) schema to determine whether the execution should be allowed to continue or stop.
-
      * Parameter Type: FailureHandling
-
      * Mandatory: Optional
 
 * **Examples**:
 
-1. You want to take TestOps Vision screenshot of an element that you captured using WebSpy and stored in Test Object > UI > logo. Checkpoint name is 'logo'. Default [failure handling](/x/qAAM) is used:
+1. You want to take a screenshot of an element that you have captured by using Katalon Spy Utility and stored in Test Object > UI > logo for TestOps Vision. The checkpoint's name is 'logo'. The default [failure handling](/x/qAAM) is used:
+
 ``` groovy
 import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
 
 WebUI.takeElementScreenshotAsCheckpoint('logo', findTestObject('UI/logo'))
 ```
-2. You want to take TestOps Vision screenshot of an TestObject stored in a variable named 'header'. Set the checkpointName to 'header':
+
+2. You want to take a screenshot of a Test Object stored in a variable named 'header' for TestOps Vision. Set the checkpointName to 'header':
 ``` groovy
 import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
 

--- a/pages/katalon-studio/docs/webui-take-element-screenshot-as-checkpoint.md
+++ b/pages/katalon-studio/docs/webui-take-element-screenshot-as-checkpoint.md
@@ -8,13 +8,13 @@ permalink: katalon-studio/docs/webui-take-element-screenshot-as-checkpoint.html
 
 ## takeElementScreenshotAsCheckpoint
 
-*  **Description**: Take screenshot of a specific web element to send to TestOps Vision. The captured image will be saved with '.png' format and stored in the 'keyes' folder in report folder.
+*  **Description**: Take a screenshot of a specific web element to send to TestOps Vision. The captured image will be saved in '.png' format and stored in the 'keyes' folder in the report folder.
 *  **Keyword name**: takeElementScreenshotAsCheckpoint
 *  **Keyword syntax**: `WebUI.takeElementScreenshotAsCheckpoint(checkpointName, to, flowControl)`
 *  **Parameters**:
 
    * Name: checkpointName 
-     * Description: A String that represents the name of the image on TestOps Vision. On local machine this name will be appended with TestOps Vision prefix('keyes-').
+     * Description: A String that represents the name of the image on TestOps Vision. On a local machine, this name will be appended with TestOps Vision prefix('keyes-').
      * Parameter Type: String
      * Mandatory: Required
      
@@ -30,7 +30,7 @@ permalink: katalon-studio/docs/webui-take-element-screenshot-as-checkpoint.html
 
 * **Examples**:
 
-1. You want to take a screenshot of an element that you have captured by using Katalon Spy Utility and stored in Test Object > UI > logo for TestOps Vision. The checkpoint's name is 'logo'. The default [failure handling](/x/qAAM) is used:
+1. You want to take a screenshot of an element that you have captured by using Katalon Spy Utility and stored in Test Object > UI > logo for TestOps Vision. The checkpoint's name is 'logo'. Default [failure handling](/x/qAAM) is used:
 
 ``` groovy
 import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
@@ -39,6 +39,7 @@ WebUI.takeElementScreenshotAsCheckpoint('logo', findTestObject('UI/logo'))
 ```
 
 2. You want to take a screenshot of a Test Object stored in a variable named 'header' for TestOps Vision. Set the checkpointName to 'header':
+
 ``` groovy
 import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
 

--- a/pages/katalon-studio/docs/webui-take-element-screenshot-as-checkpoint.md
+++ b/pages/katalon-studio/docs/webui-take-element-screenshot-as-checkpoint.md
@@ -1,0 +1,63 @@
+---
+
+title: "[WebUI] Take Element Screenshot As Checkpoint"
+
+sidebar: katalon_studio_docs_sidebar
+
+permalink: katalon-studio/docs/webui-take-element-screeenshot-as-checkpoint.html
+
+---
+
+> From version **7.7.0**, this keyword is available.
+
+  
+
+## takeElementScreenshotAsCheckpoint
+
+  
+
+*  **Description**: Take screenshot of a specific web element to send to TestOps Vision. The captured image will be saved in '.png' format and stored in 'keyes' folder in report folder.
+
+*  **Keyword name**: takeElementScreenshotAsCheckpoint
+
+*  **Keyword syntax**: WebUI.takeElementScreenshotAsCheckpoint(checkpointName, to, flowControl)
+
+*  **Parameters**:
+   * Name: checkpointName 
+
+     * Description: A String that represents the name of the image on TestOps Vision. On local machine this name will be appended with TestOps Vision prefix('keyes-').
+
+     * Parameter Type: String
+
+     * Mandatory: Required
+     
+    * Name: to
+	    * Description: TestObject which represents the element you want to take screenshot.
+
+       * Parameter Type: TestObject
+
+       * Mandatory: Required
+
+   * Name: flowControl
+
+     * Description: Specify [failure handling](/x/qAAM) schema to determine whether the execution should be allowed to continue or stop.
+
+     * Parameter Type: FailureHandling
+
+     * Mandatory: Optional
+
+* **Examples**:
+
+1. You want to take TestOps Vision screenshot of an element that you captured using WebSpy and stored in Test Object > UI > logo. Checkpoint name is 'logo'. Default [failure handling](/x/qAAM) is used:
+``` groovy
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+
+WebUI.takeElementScreenshotAsCheckpoint('logo', findTestObject('UI/logo'))
+```
+2. You want to take TestOps Vision screenshot of an TestObject stored in a variable named 'header'. Set the checkpointName to 'header':
+``` groovy
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+
+// where ignoredElements is a user-defined List-typed variable.
+WebUI.takeElementScreenshotAsCheckpoint('header', header)
+```

--- a/pages/katalon-studio/docs/webui-take-element-screenshot.md
+++ b/pages/katalon-studio/docs/webui-take-element-screenshot.md
@@ -1,61 +1,46 @@
 ---
-
 title: "[WebUI] Take Element Screenshot"
-
 sidebar: katalon_studio_docs_sidebar
-
 permalink: katalon-studio/docs/webui-take-element-screenshot.html
-
 ---
 
 > From version **7.7.0**, this keyword is available.
 
-  
-
-## takeElementScreenshot
-
-  
+## takeElementScreenshot 
 
 *  **Description**: Take screenshot of a specific web element. The captured image will be saved in '.png' format.
-
 *  **Keyword name**: takeElementScreenshot
-
-*  **Keyword syntax**: WebUI.takeElementScreenshot(fileName, to, flowControl)
-
+*  **Keyword syntax**: `WebUI.takeElementScreenshot(fileName, to, flowControl)`
 *  **Parameters**:
+
    * Name: fileName 
-
      * Description: A String that represents the path to the saved image. The path can be absolute path or relative path.
-
      * Parameter Type: String
-
      * Mandatory: Optional
      
-    * Name: to
-	    * Description: TestObject which represents the element you want to take screenshot.
-
-       * Parameter Type: TestObject
-
-       * Mandatory: Optional
+   * Name: to
+     * Description: TestObject which represents the element you want to take screenshot.
+     * Parameter Type: TestObject
+     * Mandatory: Optional
 
    * Name: flowControl
-
      * Description: Specify [failure handling](/x/qAAM) schema to determine whether the execution should be allowed to continue or stop.
-
      * Parameter Type: FailureHandling
-
      * Mandatory: Optional
 
 * **Examples**:
 
-1. You want to take screenshot of an element that you captured using WebSpy and stored in Test Object > UI > logo. Filename is 'logo.png' and stored in report folder. Default [failure handling](/x/qAAM) is used:
+1. You want to take screenshot of an element that you have captured by using Katalon Spy Utility and stored in Test Object > UI > logo. The file name is 'logo.png' and stored in the report folder. Default [failure handling](/x/qAAM) is used:
+
 ``` groovy
 import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
 import com.kms.katalon.core.configuration.RunConfiguration as RunConfiguration
 
 WebUI.takeElementScreenshot(RunConfiguration.getReportFolder() + '/logo.png', findTestObject('UI/logo'))
 ```
-2. You want to take TestOps Vision screenshot of an TestObject stored in a variable named 'header'. Use default fileName:
+
+2. You want to take screenshot of a Test Object stored in a variable named 'header' for TestOps Vision. Use the default fileName:
+
 ``` groovy
 import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
 

--- a/pages/katalon-studio/docs/webui-take-element-screenshot.md
+++ b/pages/katalon-studio/docs/webui-take-element-screenshot.md
@@ -4,7 +4,7 @@ title: "[WebUI] Take Element Screenshot"
 
 sidebar: katalon_studio_docs_sidebar
 
-permalink: katalon-studio/docs/webui-take-element-screeenshot.html
+permalink: katalon-studio/docs/webui-take-element-screenshot.html
 
 ---
 

--- a/pages/katalon-studio/docs/webui-take-element-screenshot.md
+++ b/pages/katalon-studio/docs/webui-take-element-screenshot.md
@@ -1,0 +1,64 @@
+---
+
+title: "[WebUI] Take Element Screenshot"
+
+sidebar: katalon_studio_docs_sidebar
+
+permalink: katalon-studio/docs/webui-take-element-screeenshot.html
+
+---
+
+> From version **7.7.0**, this keyword is available.
+
+  
+
+## takeElementScreenshot
+
+  
+
+*  **Description**: Take screenshot of a specific web element. The captured image will be saved in '.png' format.
+
+*  **Keyword name**: takeElementScreenshot
+
+*  **Keyword syntax**: WebUI.takeElementScreenshot(fileName, to, flowControl)
+
+*  **Parameters**:
+   * Name: fileName 
+
+     * Description: A String that represents the path to the saved image. The path can be absolute path or relative path.
+
+     * Parameter Type: String
+
+     * Mandatory: Optional
+     
+    * Name: to
+	    * Description: TestObject which represents the element you want to take screenshot.
+
+       * Parameter Type: TestObject
+
+       * Mandatory: Optional
+
+   * Name: flowControl
+
+     * Description: Specify [failure handling](/x/qAAM) schema to determine whether the execution should be allowed to continue or stop.
+
+     * Parameter Type: FailureHandling
+
+     * Mandatory: Optional
+
+* **Examples**:
+
+1. You want to take screenshot of an element that you captured using WebSpy and stored in Test Object > UI > logo. Filename is 'logo.png' and stored in report folder. Default [failure handling](/x/qAAM) is used:
+``` groovy
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+import com.kms.katalon.core.configuration.RunConfiguration as RunConfiguration
+
+WebUI.takeElementScreenshot(RunConfiguration.getReportFolder() + '/logo.png', findTestObject('UI/logo'))
+```
+2. You want to take TestOps Vision screenshot of an TestObject stored in a variable named 'header'. Use default fileName:
+``` groovy
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+
+// where ignoredElements is a user-defined List-typed variable.
+WebUI.takeElementScreenshot(header)
+```

--- a/pages/katalon-studio/docs/webui-take-element-screenshot.md
+++ b/pages/katalon-studio/docs/webui-take-element-screenshot.md
@@ -8,18 +8,18 @@ permalink: katalon-studio/docs/webui-take-element-screenshot.html
 
 ## takeElementScreenshot 
 
-*  **Description**: Take screenshot of a specific web element. The captured image will be saved in '.png' format.
+*  **Description**: Take a screenshot of a specific web element. The captured image will be saved in '.png' format.
 *  **Keyword name**: takeElementScreenshot
 *  **Keyword syntax**: `WebUI.takeElementScreenshot(fileName, to, flowControl)`
 *  **Parameters**:
 
    * Name: fileName 
-     * Description: A String that represents the path to the saved image. The path can be absolute path or relative path.
+     * Description: A String that represents a path to the saved image. The path can be absolute path or relative path.
      * Parameter Type: String
      * Mandatory: Optional
      
    * Name: to
-     * Description: TestObject which represents the element you want to take screenshot.
+     * Description: A Test Object which represents the element you want to take screenshot of.
      * Parameter Type: TestObject
      * Mandatory: Optional
 
@@ -30,7 +30,7 @@ permalink: katalon-studio/docs/webui-take-element-screenshot.html
 
 * **Examples**:
 
-1. You want to take screenshot of an element that you have captured by using Katalon Spy Utility and stored in Test Object > UI > logo. The file name is 'logo.png' and stored in the report folder. Default [failure handling](/x/qAAM) is used:
+1. You want to take a screenshot of an element that you have captured by using Katalon Spy Utility and stored in Test Object > UI > logo. The file name is 'logo.png' and stored in the report folder. Default [failure handling](/x/qAAM) is used:
 
 ``` groovy
 import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
@@ -39,7 +39,7 @@ import com.kms.katalon.core.configuration.RunConfiguration as RunConfiguration
 WebUI.takeElementScreenshot(RunConfiguration.getReportFolder() + '/logo.png', findTestObject('UI/logo'))
 ```
 
-2. You want to take screenshot of a Test Object stored in a variable named 'header' for TestOps Vision. Use the default fileName:
+2. You want to take a screenshot of a Test Object stored in a variable named 'header' for TestOps Vision. Use the default fileName:
 
 ``` groovy
 import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject

--- a/pages/katalon-studio/docs/webui-take-fullpage-screenshot-as-checkpoint.md
+++ b/pages/katalon-studio/docs/webui-take-fullpage-screenshot-as-checkpoint.md
@@ -1,0 +1,67 @@
+---
+
+title: "[WebUI] Take Full Page Screenshot As Checkpoint"
+
+sidebar: katalon_studio_docs_sidebar
+
+permalink: katalon-studio/docs/webui-take-fullpage-screeenshot-as-checkpoint.html
+
+---
+
+> From version **7.7.0**, this keyword is available.
+
+> **Warning**: If this method is used with ignored elements, JavaScript is required to be enabled on test browser. The method used to take screenshot is simulating scroll action to take screenshot to the end the page. If the web page uses infinity-scrolling then it's not recommended to use this keyword.
+
+  
+
+## takeFullPageScreenshotAsCheckpoint
+
+  
+
+*  **Description**: Take entire-page screenshot to send to TestOps Vision. The captured image will be saved in '.png' format and stored in 'keyes' folder in report folder. This method simulates scroll action to take numbers of shot and merges them to make a full-page screenshot.
+
+*  **Keyword name**: takeFullPageScreenshotAsCheckpoint
+
+*  **Keyword syntax**: WebUI.takeFullPageScreenshotAsCheckpoint(checkpointName, ignoredElements, flowControl)
+
+*  **Parameters**:
+   * Name: checkpointName 
+
+     * Description: A String that represents the name of the image on TestOps Vision. On local machine this name will be appended with TestOps Vision prefix('keyes-').
+
+     * Parameter Type: String
+
+     * Mandatory: Required
+     
+    * Name: ignoredElements
+	    * Description: List of TestObject you want to hide when taking screenshot.
+
+       * Parameter Type: List<TestObject\>
+
+       * Mandatory: Optional
+
+   * Name: flowControl
+
+     * Description: Specify [failure handling](/x/qAAM) schema to determine whether the execution should be allowed to continue or stop.
+
+     * Parameter Type: FailureHandling
+
+     * Mandatory: Optional
+
+* **Examples**:
+
+1. You want to take full-page screenshot as TestOps Vision checkpoint named 'full-page' and use default [failure handling](/x/qAAM):
+``` groovy
+WebUI.takeFullPageScreenshotAsCheckpoint('current_viewport')
+```
+2. You want to take full-page screenshot as TestOps Vision checkpoint named 'full_view_no_logo' and hide some web elements:
+``` groovy
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+
+WebUI.takeFullPageScreenshotAsCheckpoint('full_view_no_elements', [findTestObject('UI/logo')])
+```
+3. You want to take full-page screenshot as TestOps Vision checkpoint named 'full_view_no_elements' and hide some web elements that defined in variable named 'ignoredElements':
+``` groovy
+// where ignoredElements is a user-defined List-typed variable.
+WebUI.takeFullPageScreenshotAsCheckpoint('full_view_no_elements', ignoredElements)
+```

--- a/pages/katalon-studio/docs/webui-take-fullpage-screenshot-as-checkpoint.md
+++ b/pages/katalon-studio/docs/webui-take-fullpage-screenshot-as-checkpoint.md
@@ -8,22 +8,22 @@ permalink: katalon-studio/docs/webui-take-fullpage-screenshot-as-checkpoint.html
 
 > From version **7.7.0**, this keyword is available.
 
-**Warning**: If this method is used with the ignored elements, JavaScript is required to be enabled on test browser. The method used to take entire-page screenshot is simulating a scroll action to the end of the page. If the web page uses infinity-scrolling, it's not recommended to use this keyword.
+**Warning**: If this method is used with the ignored elements, JavaScript is required to be enabled on test browser. The method used to take an entire-page screenshot is simulating a scroll action to the end of the page. If the web page uses infinity-scrolling, it's not recommended to use this keyword.
 
 ## takeFullPageScreenshotAsCheckpoint
 
-*  **Description**: Take entire-page screenshot to send to TestOps Vision. The captured image will be saved in '.png' format and stored in 'keyes' folder in report folder. This method simulates scroll action to take numbers of shot and merges them to make a full-page screenshot.
+*  **Description**: Take an entire-page screenshot to send to TestOps Vision. The captured image will be saved in '.png' format and stored in the 'keyes' folder in the report folder. This method simulates a scroll action, takes a numbers of shots, then merges them together to make a full-page screenshot.
 *  **Keyword name**: takeFullPageScreenshotAsCheckpoint
 *  **Keyword syntax**: `WebUI.takeFullPageScreenshotAsCheckpoint(checkpointName, ignoredElements, flowControl)`
 *  **Parameters**:
 
    * Name: checkpointName 
-     * Description: A String that represents the name of the image on TestOps Vision. On local machine this name will be appended with TestOps Vision prefix('keyes-').
+     * Description: A String that represents the name of the image on TestOps Vision. On local machine, this name will be appended with TestOps Vision prefix('keyes-').
      * Parameter Type: String
      * Mandatory: Required
      
    * Name: ignoredElements
-     * Description: List of TestObject you want to hide when taking screenshot.
+     * Description: List of Test Objects you want to hide when taking a screenshot.
      * Parameter Type: List<TestObject\>
      * Mandatory: Optional
 
@@ -34,11 +34,11 @@ permalink: katalon-studio/docs/webui-take-fullpage-screenshot-as-checkpoint.html
 
 * **Examples**:
 
-1. You want to take full-page screenshot as TestOps Vision checkpoint named 'full-page' and use default [failure handling](/x/qAAM):
+1. You want to take a full-page screenshot as TestOps Vision checkpoint named 'full-page' and use default [failure handling](/x/qAAM):
 ``` groovy
 WebUI.takeFullPageScreenshotAsCheckpoint('current_viewport')
 ```
-2. You want to take full-page screenshot as TestOps Vision checkpoint named 'full_view_no_logo' and hide some web elements:
+2. You want to take a full-page screenshot as TestOps Vision checkpoint named 'full_view_no_logo' and hide some web elements:
 
 ``` groovy
 import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
@@ -46,7 +46,7 @@ import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
 WebUI.takeFullPageScreenshotAsCheckpoint('full_view_no_elements', [findTestObject('UI/logo')])
 ```
 
-3. You want to take full-page screenshot as TestOps Vision checkpoint named 'full_view_no_elements' and hide some web elements defined in a variable named 'ignoredElements':
+3. You want to take a full-page screenshot as TestOps Vision checkpoint named 'full_view_no_elements' and hide some web elements defined in a variable named 'ignoredElements':
 
 ``` groovy
 // where ignoredElements is a user-defined List-typed variable.

--- a/pages/katalon-studio/docs/webui-take-fullpage-screenshot-as-checkpoint.md
+++ b/pages/katalon-studio/docs/webui-take-fullpage-screenshot-as-checkpoint.md
@@ -1,51 +1,35 @@
 ---
 
 title: "[WebUI] Take Full Page Screenshot As Checkpoint"
-
 sidebar: katalon_studio_docs_sidebar
-
 permalink: katalon-studio/docs/webui-take-fullpage-screenshot-as-checkpoint.html
 
 ---
 
 > From version **7.7.0**, this keyword is available.
 
-> **Warning**: If this method is used with ignored elements, JavaScript is required to be enabled on test browser. The method used to take screenshot is simulating scroll action to take screenshot to the end the page. If the web page uses infinity-scrolling then it's not recommended to use this keyword.
-
-  
+**Warning**: If this method is used with the ignored elements, JavaScript is required to be enabled on test browser. The method used to take entire-page screenshot is simulating a scroll action to the end of the page. If the web page uses infinity-scrolling, it's not recommended to use this keyword.
 
 ## takeFullPageScreenshotAsCheckpoint
 
-  
-
 *  **Description**: Take entire-page screenshot to send to TestOps Vision. The captured image will be saved in '.png' format and stored in 'keyes' folder in report folder. This method simulates scroll action to take numbers of shot and merges them to make a full-page screenshot.
-
 *  **Keyword name**: takeFullPageScreenshotAsCheckpoint
-
-*  **Keyword syntax**: WebUI.takeFullPageScreenshotAsCheckpoint(checkpointName, ignoredElements, flowControl)
-
+*  **Keyword syntax**: `WebUI.takeFullPageScreenshotAsCheckpoint(checkpointName, ignoredElements, flowControl)`
 *  **Parameters**:
+
    * Name: checkpointName 
-
      * Description: A String that represents the name of the image on TestOps Vision. On local machine this name will be appended with TestOps Vision prefix('keyes-').
-
      * Parameter Type: String
-
      * Mandatory: Required
      
-    * Name: ignoredElements
-	    * Description: List of TestObject you want to hide when taking screenshot.
-
-       * Parameter Type: List<TestObject\>
-
-       * Mandatory: Optional
+   * Name: ignoredElements
+     * Description: List of TestObject you want to hide when taking screenshot.
+     * Parameter Type: List<TestObject\>
+     * Mandatory: Optional
 
    * Name: flowControl
-
      * Description: Specify [failure handling](/x/qAAM) schema to determine whether the execution should be allowed to continue or stop.
-
      * Parameter Type: FailureHandling
-
      * Mandatory: Optional
 
 * **Examples**:
@@ -55,12 +39,15 @@ permalink: katalon-studio/docs/webui-take-fullpage-screenshot-as-checkpoint.html
 WebUI.takeFullPageScreenshotAsCheckpoint('current_viewport')
 ```
 2. You want to take full-page screenshot as TestOps Vision checkpoint named 'full_view_no_logo' and hide some web elements:
+
 ``` groovy
 import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
 
 WebUI.takeFullPageScreenshotAsCheckpoint('full_view_no_elements', [findTestObject('UI/logo')])
 ```
-3. You want to take full-page screenshot as TestOps Vision checkpoint named 'full_view_no_elements' and hide some web elements that defined in variable named 'ignoredElements':
+
+3. You want to take full-page screenshot as TestOps Vision checkpoint named 'full_view_no_elements' and hide some web elements defined in a variable named 'ignoredElements':
+
 ``` groovy
 // where ignoredElements is a user-defined List-typed variable.
 WebUI.takeFullPageScreenshotAsCheckpoint('full_view_no_elements', ignoredElements)

--- a/pages/katalon-studio/docs/webui-take-fullpage-screenshot-as-checkpoint.md
+++ b/pages/katalon-studio/docs/webui-take-fullpage-screenshot-as-checkpoint.md
@@ -4,7 +4,7 @@ title: "[WebUI] Take Full Page Screenshot As Checkpoint"
 
 sidebar: katalon_studio_docs_sidebar
 
-permalink: katalon-studio/docs/webui-take-fullpage-screeenshot-as-checkpoint.html
+permalink: katalon-studio/docs/webui-take-fullpage-screenshot-as-checkpoint.html
 
 ---
 

--- a/pages/katalon-studio/docs/webui-take-fullpage-screenshot.md
+++ b/pages/katalon-studio/docs/webui-take-fullpage-screenshot.md
@@ -1,0 +1,68 @@
+---
+
+title: "[WebUI] Take Full Page Screenshot"
+
+sidebar: katalon_studio_docs_sidebar
+
+permalink: katalon-studio/docs/webui-take-fullpage-screeenshot.html
+
+---
+
+> From version **7.7.0**, this keyword is available.
+
+> **Warning**: If this method is used with ignored elements, JavaScript is required to be enabled on test browser. The method used to take screenshot is simulating scroll action to take screenshot to the end the page. If the web page uses infinity-scrolling then it's not recommended to use this keyword.
+
+  
+
+## takeFullPageScreenshot
+
+  
+
+*  **Description**: Take entire-page screenshot, overflow parts included. The captured image will be saved in '.png' format. This method simulates scroll action to take numbers of shot and merges them to make a full-page screenshot.
+
+*  **Keyword name**: takeFullPageScreenshot
+
+*  **Keyword syntax**: WebUI.takeFullPageScreenshot(fileName, ignoredElements, flowControl)
+
+*  **Parameters**:
+   * Name: fileName 
+
+     * Description: A String that represents the path to the saved image. The path can be absolute path or relative path.
+
+     * Parameter Type: String
+
+     * Mandatory: Optional
+     
+    * Name: ignoredElements
+	    * Description: List of TestObject you want to hide when taking screenshot.
+
+       * Parameter Type: List<TestObject\>
+
+       * Mandatory: Optional
+
+   * Name: flowControl
+
+     * Description: Specify [failure handling](/x/qAAM) schema to determine whether the execution should be allowed to continue or stop.
+
+     * Parameter Type: FailureHandling
+
+     * Mandatory: Optional
+
+* **Examples**:
+
+1. You want to take full-page screenshot with default name and use default [failure handling](/x/qAAM). No elements is going to be hidden:
+``` groovy
+WebUI.takeFullPageScreenshot()
+```
+2. You want to take full-page screenshot saved to file named 'full_view_no_logo.png' in report folder and hide some web elements:
+``` groovy
+import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
+import com.kms.katalon.core.configuration.RunConfiguration as RunConfiguration
+
+WebUI.takeFullPageScreenshot(RunConfiguration.getReportFolder() + '/full_view_no_elements.png', [findTestObject('UI/logo')])
+```
+3. You want to take full-page screenshot saved to file 'E:\\full_view_no_elements.png' and hide some web elements that defined in variable named 'ignoredElements':
+``` groovy
+// where ignoredElements is a user-defined List-typed variable.
+WebUI.takeFullPageScreenshot('E:\\full_view_no_elements.png', ignoredElements)
+```

--- a/pages/katalon-studio/docs/webui-take-fullpage-screenshot.md
+++ b/pages/katalon-studio/docs/webui-take-fullpage-screenshot.md
@@ -1,67 +1,55 @@
 ---
 
 title: "[WebUI] Take Full Page Screenshot"
-
 sidebar: katalon_studio_docs_sidebar
-
 permalink: katalon-studio/docs/webui-take-fullpage-screenshot.html
 
 ---
 
 > From version **7.7.0**, this keyword is available.
 
-> **Warning**: If this method is used with ignored elements, JavaScript is required to be enabled on test browser. The method used to take screenshot is simulating scroll action to take screenshot to the end the page. If the web page uses infinity-scrolling then it's not recommended to use this keyword.
-
-  
+**Warning**: If this method is used with the ignored elements, JavaScript is required to be enabled on test browser. The method used to take full-paged screenshot is simulating a scroll action to the end of the page. If the web page uses infinity-scrolling, it's not recommended to use this keyword. 
 
 ## takeFullPageScreenshot
 
-  
-
 *  **Description**: Take entire-page screenshot, overflow parts included. The captured image will be saved in '.png' format. This method simulates scroll action to take numbers of shot and merges them to make a full-page screenshot.
-
 *  **Keyword name**: takeFullPageScreenshot
-
-*  **Keyword syntax**: WebUI.takeFullPageScreenshot(fileName, ignoredElements, flowControl)
-
+*  **Keyword syntax**: `WebUI.takeFullPageScreenshot(fileName, ignoredElements, flowControl)`
 *  **Parameters**:
    * Name: fileName 
-
      * Description: A String that represents the path to the saved image. The path can be absolute path or relative path.
-
      * Parameter Type: String
-
      * Mandatory: Optional
      
-    * Name: ignoredElements
-	    * Description: List of TestObject you want to hide when taking screenshot.
-
-       * Parameter Type: List<TestObject\>
-
-       * Mandatory: Optional
+   * Name: ignoredElements
+     * Description: List of TestObject you want to hide when taking screenshot.
+     * Parameter Type: List<TestObject\>
+     * Mandatory: Optional
 
    * Name: flowControl
-
      * Description: Specify [failure handling](/x/qAAM) schema to determine whether the execution should be allowed to continue or stop.
-
      * Parameter Type: FailureHandling
-
      * Mandatory: Optional
 
 * **Examples**:
 
-1. You want to take full-page screenshot with default name and use default [failure handling](/x/qAAM). No elements is going to be hidden:
+1. Given that no elements are going to be hidden, you want to take full-page screenshot with a default name and use a default [failure handling](/x/qAAM):
+
 ``` groovy
 WebUI.takeFullPageScreenshot()
 ```
-2. You want to take full-page screenshot saved to file named 'full_view_no_logo.png' in report folder and hide some web elements:
+
+2. You want to take full-page screenshot saved to a file named 'full_view_no_logo.png' in the report folder and hide some web elements:
+
 ``` groovy
 import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
 import com.kms.katalon.core.configuration.RunConfiguration as RunConfiguration
 
 WebUI.takeFullPageScreenshot(RunConfiguration.getReportFolder() + '/full_view_no_elements.png', [findTestObject('UI/logo')])
 ```
-3. You want to take full-page screenshot saved to file 'E:\\full_view_no_elements.png' and hide some web elements that defined in variable named 'ignoredElements':
+
+3. You want to take full-page screenshot saved to a file 'E:\\full_view_no_elements.png' and hide some web elements defined in a variable named 'ignoredElements':
+
 ``` groovy
 // where ignoredElements is a user-defined List-typed variable.
 WebUI.takeFullPageScreenshot('E:\\full_view_no_elements.png', ignoredElements)

--- a/pages/katalon-studio/docs/webui-take-fullpage-screenshot.md
+++ b/pages/katalon-studio/docs/webui-take-fullpage-screenshot.md
@@ -8,11 +8,11 @@ permalink: katalon-studio/docs/webui-take-fullpage-screenshot.html
 
 > From version **7.7.0**, this keyword is available.
 
-**Warning**: If this method is used with the ignored elements, JavaScript is required to be enabled on test browser. The method used to take full-paged screenshot is simulating a scroll action to the end of the page. If the web page uses infinity-scrolling, it's not recommended to use this keyword. 
+**Warning**: If this method is used with the ignored elements, JavaScript is required to be enabled on test browser. The method used to take a full-paged screenshot is simulating a scroll action to the end of the page. If the web page uses infinity-scrolling, it's not recommended to use this keyword. 
 
 ## takeFullPageScreenshot
 
-*  **Description**: Take entire-page screenshot, overflow parts included. The captured image will be saved in '.png' format. This method simulates scroll action to take numbers of shot and merges them to make a full-page screenshot.
+*  **Description**: Take entire-page screenshot, including overflow parts. The captured image will be saved in '.png' format. This method simulates a scroll action to take a number of shots and merge them together to make a full-page screenshot.
 *  **Keyword name**: takeFullPageScreenshot
 *  **Keyword syntax**: `WebUI.takeFullPageScreenshot(fileName, ignoredElements, flowControl)`
 *  **Parameters**:
@@ -22,7 +22,7 @@ permalink: katalon-studio/docs/webui-take-fullpage-screenshot.html
      * Mandatory: Optional
      
    * Name: ignoredElements
-     * Description: List of TestObject you want to hide when taking screenshot.
+     * Description: List of Test Objects you want to hide when taking a screenshot.
      * Parameter Type: List<TestObject\>
      * Mandatory: Optional
 
@@ -33,13 +33,13 @@ permalink: katalon-studio/docs/webui-take-fullpage-screenshot.html
 
 * **Examples**:
 
-1. Given that no elements are going to be hidden, you want to take full-page screenshot with a default name and use a default [failure handling](/x/qAAM):
+1. Given that no elements are going to be hidden, you want to take a full-page screenshot with a default name and use default [failure handling](/x/qAAM):
 
 ``` groovy
 WebUI.takeFullPageScreenshot()
 ```
 
-2. You want to take full-page screenshot saved to a file named 'full_view_no_logo.png' in the report folder and hide some web elements:
+2. You want to take a full-page screenshot that will be saved in a file named 'full_view_no_logo.png' in the report folder and hide some web elements:
 
 ``` groovy
 import static com.kms.katalon.core.testobject.ObjectRepository.findTestObject
@@ -48,7 +48,7 @@ import com.kms.katalon.core.configuration.RunConfiguration as RunConfiguration
 WebUI.takeFullPageScreenshot(RunConfiguration.getReportFolder() + '/full_view_no_elements.png', [findTestObject('UI/logo')])
 ```
 
-3. You want to take full-page screenshot saved to a file 'E:\\full_view_no_elements.png' and hide some web elements defined in a variable named 'ignoredElements':
+3. You want to take a full-page screenshot that will be saved to a file 'E:\\full_view_no_elements.png' and hide some web elements defined in a variable named 'ignoredElements':
 
 ``` groovy
 // where ignoredElements is a user-defined List-typed variable.

--- a/pages/katalon-studio/docs/webui-take-fullpage-screenshot.md
+++ b/pages/katalon-studio/docs/webui-take-fullpage-screenshot.md
@@ -4,7 +4,7 @@ title: "[WebUI] Take Full Page Screenshot"
 
 sidebar: katalon_studio_docs_sidebar
 
-permalink: katalon-studio/docs/webui-take-fullpage-screeenshot.html
+permalink: katalon-studio/docs/webui-take-fullpage-screenshot.html
 
 ---
 

--- a/pages/katalon-studio/docs/webui-take-screenshot-as-checkpoint.md
+++ b/pages/katalon-studio/docs/webui-take-screenshot-as-checkpoint.md
@@ -1,51 +1,40 @@
 ---
 
 title: "[WebUI] Take Screenshot As Checkpoint"
-
 sidebar: katalon_studio_docs_sidebar
-
 permalink: katalon-studio/docs/webui-take-screenshot-as-checkpoint.html
 
 ---
 
 > From version 7.7.0, this keyword is available.
 
-  
-
 ## takeScreenshotAsCheckpoint
 
-  
-
 *  **Description**: Take screenshot of current view-port to send to TestOps Vision. The captured image will be saved in '.png' format and stored in 'keyes' folder in report folder.
-
 *  **Keyword name**: takeScreenshotAsCheckpoint
-
-*  **Keyword syntax**: WebUI.takeScreenshotAsCheckpoint(checkpointName, flowControl)
-
+*  **Keyword syntax**: `WebUI.takeScreenshotAsCheckpoint(checkpointName, flowControl)`
 *  **Parameters**:
+
    * Name: checkpointName 
-
      * Description: A String that represents the name of the image on TestOps Vision. On local machine this name will be appended with TestOps Vision prefix('keyes-').
-
      * Parameter Type: String
-
      * Mandatory: Required
 
    * Name: flowControl
-
      * Description: Specify [failure handling](/x/qAAM) schema to determine whether the execution should be allowed to continue or stop.
-
      * Parameter Type: FailureHandling
-
      * Mandatory: Optional
 
 * **Examples**:
 
-1. You want to take screenshot as TestOps Vision checkpoint named 'current_viewport' and use default [failure handling](/x/qAAM):
+1. You want to take screenshot as checkpoint named 'current_viewport' for TestOps Vision and use default [failure handling](/x/qAAM):
+
 ``` groovy
 WebUI.takeScreenshotAsCheckpoint('current_viewport')
 ```
-2. You want to take screenshot as TestOps Vision checkpoint named 'full_view' and need the test continue to run regardless of this step failed or passed:
+
+2. You want to take screenshot as checkpoint named 'full_view' for TestOps Vision, and need the test to keep running regardless of this step having failed or passed:
+
 ``` groovy
 import com.kms.katalon.core.model.FailureHandling as FailureHandling
 

--- a/pages/katalon-studio/docs/webui-take-screenshot-as-checkpoint.md
+++ b/pages/katalon-studio/docs/webui-take-screenshot-as-checkpoint.md
@@ -4,7 +4,7 @@ title: "[WebUI] Take Screenshot As Checkpoint"
 
 sidebar: katalon_studio_docs_sidebar
 
-permalink: katalon-studio/docs/webui-take-screeenshot-as-checkpoint.html
+permalink: katalon-studio/docs/webui-take-screenshot-as-checkpoint.html
 
 ---
 

--- a/pages/katalon-studio/docs/webui-take-screenshot-as-checkpoint.md
+++ b/pages/katalon-studio/docs/webui-take-screenshot-as-checkpoint.md
@@ -10,13 +10,13 @@ permalink: katalon-studio/docs/webui-take-screenshot-as-checkpoint.html
 
 ## takeScreenshotAsCheckpoint
 
-*  **Description**: Take screenshot of current view-port to send to TestOps Vision. The captured image will be saved in '.png' format and stored in 'keyes' folder in report folder.
+*  **Description**: Take a screenshot of the current viewport to send to TestOps Vision. The captured image will be saved in '.png' format and stored in the 'keyes' folder inn the report folder.
 *  **Keyword name**: takeScreenshotAsCheckpoint
 *  **Keyword syntax**: `WebUI.takeScreenshotAsCheckpoint(checkpointName, flowControl)`
 *  **Parameters**:
 
    * Name: checkpointName 
-     * Description: A String that represents the name of the image on TestOps Vision. On local machine this name will be appended with TestOps Vision prefix('keyes-').
+     * Description: A String that represents the name of the image on TestOps Vision. On local machine, this name will be appended with TestOps Vision prefix('keyes-').
      * Parameter Type: String
      * Mandatory: Required
 
@@ -27,13 +27,13 @@ permalink: katalon-studio/docs/webui-take-screenshot-as-checkpoint.html
 
 * **Examples**:
 
-1. You want to take screenshot as checkpoint named 'current_viewport' for TestOps Vision and use default [failure handling](/x/qAAM):
+1. You want to take a screenshot as checkpoint named 'current_viewport' for TestOps Vision and use default [failure handling](/x/qAAM):
 
 ``` groovy
 WebUI.takeScreenshotAsCheckpoint('current_viewport')
 ```
 
-2. You want to take screenshot as checkpoint named 'full_view' for TestOps Vision, and need the test to keep running regardless of this step having failed or passed:
+2. You want to take a screenshot as checkpoint named 'full_view' for TestOps Vision, and need the test to keep running regardless of this step having failed or passed:
 
 ``` groovy
 import com.kms.katalon.core.model.FailureHandling as FailureHandling

--- a/pages/katalon-studio/docs/webui-take-screenshot-as-checkpoint.md
+++ b/pages/katalon-studio/docs/webui-take-screenshot-as-checkpoint.md
@@ -1,0 +1,53 @@
+---
+
+title: "[WebUI] Take Screenshot As Checkpoint"
+
+sidebar: katalon_studio_docs_sidebar
+
+permalink: katalon-studio/docs/webui-take-screeenshot-as-checkpoint.html
+
+---
+
+> From version 7.7.0, this keyword is available.
+
+  
+
+## takeScreenshotAsCheckpoint
+
+  
+
+*  **Description**: Take screenshot of current view-port to send to TestOps Vision. The captured image will be saved in '.png' format and stored in 'keyes' folder in report folder.
+
+*  **Keyword name**: takeScreenshotAsCheckpoint
+
+*  **Keyword syntax**: WebUI.takeScreenshotAsCheckpoint(checkpointName, flowControl)
+
+*  **Parameters**:
+   * Name: checkpointName 
+
+     * Description: A String that represents the name of the image on TestOps Vision. On local machine this name will be appended with TestOps Vision prefix('keyes-').
+
+     * Parameter Type: String
+
+     * Mandatory: Required
+
+   * Name: flowControl
+
+     * Description: Specify [failure handling](/x/qAAM) schema to determine whether the execution should be allowed to continue or stop.
+
+     * Parameter Type: FailureHandling
+
+     * Mandatory: Optional
+
+* **Examples**:
+
+1. You want to take screenshot as TestOps Vision checkpoint named 'current_viewport' and use default [failure handling](/x/qAAM):
+``` groovy
+WebUI.takeScreenshotAsCheckpoint('current_viewport')
+```
+2. You want to take screenshot as TestOps Vision checkpoint named 'full_view' and need the test continue to run regardless of this step failed or passed:
+``` groovy
+import com.kms.katalon.core.model.FailureHandling as FailureHandling
+
+WebUI.takeScreenshotAsCheckpoint('full_view', FailureHandling.CONTINUE_ON_FAILURE)
+```


### PR DESCRIPTION
**New WebUI keyword**
  * WebUI.takeScreenshotAsCheckpoint(String checkpointName)
  * WebUI.takeAreaScreenshotAsCheckpoint(String checkpointName, Rectangle rect, FailureHandling flowControl)
  * WebUI.takeElementScreenshotAsCheckpoint(String checkpointName, TestObject to, FailureHandling flowControl)
  * WebUI.takeFullPageScreenshotAsCheckpoint(String checkpointName, List<TestObject> ignoredElements, FailureHandling flowControl)