### PR TITLE
WIP - 7.7 release

### DIFF
--- a/_data/sidebars/katalon_studio_docs_sidebar.yml
+++ b/_data/sidebars/katalon_studio_docs_sidebar.yml
@@ -509,6 +509,20 @@ items:
                 url: /katalon-studio/docs/webui-switch-to-window-title.html
               - title: "[WebUI] Switch To Window Url"
                 url: /katalon-studio/docs/webui-switch-to-window-url.html
+              - title: "[WebUI] Take Area Screenshot As Checkpoint"
+                url: /katalon-studio/docs/webui-take-area-screenshot-as-checkpoint.html
+              - title: "[WebUI] Take Area Screenshot"
+                url: /katalon-studio/docs/webui-take-area-screenshot.html
+              - title: "[WebUI] Take Element Screenshot As Checkpoint"
+                url: /katalon-studio/docs/webui-take-element-screenshot-as-checkpoint.html
+              - title: "[WebUI] Take Element Screenshot"
+                url: /katalon-studio/docs/webui-take-element-screenshot.html 
+              - title: "[WebUI] Take Full Page Screenshot As Checkpoint"
+                url: /katalon-studio/docs/webui-take-fullpage-screenshot-as-checkpoint.html
+              - title: "[WebUI] Take Full Page Screenshot"
+                url: /katalon-studio/docs/webui-take-fullpage-screenshot.html
+              - title: "[WebUI] Take Screenshot As Checkpoint"
+                url: /katalon-studio/docs/webui-take-screenshot-as-checkpoint.html
               - title: "[WebUI] Take Screenshot"
                 url: /katalon-studio/docs/webui-take-screenshot.html
               - title: "[WebUI] Type On Image"

--- a/_data/sidebars/katalon_studio_docs_sidebar.yml
+++ b/_data/sidebars/katalon_studio_docs_sidebar.yml
@@ -319,12 +319,16 @@ items:
                     url: /katalon-studio/docs/draft-request.html
               - title: "Import Web Service Objects"
                 tree:
+                  - title: "Import RESTful requests from OpenAPI Specification 3.0"
+                    url: /katalon-studio/docs/import-openapi30.html
                   - title: "Import RESTful requests from Swagger 2.0"
                     url: /katalon-studio/docs/import-rest-requests-from-swagger-20.html
                   - title: "Import RESTful from Postman"
                     url: /katalon-studio/docs/import-postman.html
                   - title: "Import RESTful requests from SoapUI"
                     url: /katalon-studio/docs/import-soapui.html
+                  - title: "Import RESTful requests from WADL"
+                    url: /katalon-studio/docs/import-wadl.html 
                   - title: "Import SOAP requests from WSDL"
                     url: /katalon-studio/docs/import-soap-requests-from-wsdl.html
               - title: "Parameterize a Web Service Object"

--- a/pages/katalon-studio/docs/console-mode-execution.md
+++ b/pages/katalon-studio/docs/console-mode-execution.md
@@ -490,16 +490,23 @@ We recommend using the Command Builder to generate commands quickly and precisel
 
 2. The **Generate Command for Console Mode** is displayed. Configure your execution with the provided options:
 
-   ![](https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/console-mode-execution/command-builder.png)
+   ![](https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/console-mode-execution/command-builder-77.png)
 
    where:
 
   * **Test Suite**: The Test Suite or Test Suite Collection to be executed
-  * **Executive Platform**: Testing environment and execution profile of the execution
-  * **Override the execution profile and environment of all test suites**: Check if you want the specified `-BrowserType` and `-ExecutionProfile` in the command to override the browser type and execution profile of all test suites in the collection (available from version **7.6 onwards**)
-   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/console-mode-execution/environment.png">
+  * **Executive Platform**: 
 
-  * Other Options:
+     * **Run with** and **Profile**: Testing environment and execution profile of the execution. <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/console-mode-execution/environment.png" width=402>
+
+     * **Override the execution profile and environment of all test suites**: Check if you want the specified `-BrowserType` and `-ExecutionProfile` in the command to override the browser type and execution profile of all test suites in the collection (available from version **7.6 onwards**)
+
+   * **Authentication**: 
+   
+     * **API Keys**: API Keys are used for representing a user's credentials. The command-line options of API Key, including -apiKey=<Your_API_Key> and -apikey=<Your_API_Key> are both accepted.[Learn more](https://docs.katalon.com/katalon-studio/docs/katalon-apikey-70.html).
+     * From **version 7.7 onwards**, if you belong to more than one Organization subscribing to RE licenses, you can choose which one to validate your license usage. Katalon retrieves and displays the organizations binding to your Katalon account and having RE licenses. Once selected, the Organization ID is passed to the generated command (`-orgID=<Katalon_OrgID>`).
+
+   * **Execution Configurations** (Or **Other Options** in versions before 7.7):
    <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/console-mode-execution/other-options.png">
 
 3. Click **Generate Command** after completing the configuration.

--- a/pages/katalon-studio/docs/execution-settings.md
+++ b/pages/katalon-studio/docs/execution-settings.md
@@ -302,19 +302,25 @@ Where:
 * totalFailed: Total failed test cases
 * totalError: Total error test cases
 
-### Overriding Email Settings with Global Variables via Command line
+### Support Global Variables in Email Settings
 
-From **version 7.7 onwards**, you can override Email Settings with Global Variables via Command line. The below section guides you how to do that with a usage example.
+From **version 7.7 onwards**, you can customize Email Settings with Global Variables and override their default values via Command line. 
 
-1. [Define a Global Variable](https://docs.katalon.com/katalon-studio/docs/execution-profile-v54.html#define-a-global-variable) in your Execution Profile.
+The below section guides you how to do that with a usage example.
 
-   <img src="">
+1. [Define a Global Variable](https://docs.katalon.com/katalon-studio/docs/execution-profile-v54.html#define-a-global-variable) in your Execution Profile. 
 
-2. Parameterize that Global Variable in Email Settings by using the syntax `${GlobalVariable.name}` as a place holder in any supported locations including Sender, Recipients, Cc, Bcc, and Subject.
-   <img src="">
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/emails-settings/global-variable.png" width=668>
 
-3. Pass values to that Global Variable with the `-g_<variableName>=<variableValue>` syntax to override the Email Settings.
-   <img src="">
+2. Call the [parameterized Global Variable](https://docs.katalon.com/katalon-studio/docs/execution-profile-v54.html#parameterize-a-global-variable) in supported locations including Sender, Recipients, Cc, Bcc, and Subject by using the syntax `${GlobalVariable.name}`. For example, the declared value, "Regression Test - Latest Release", is appended to the email subject:
+
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/emails-settings/subject.png" width=578>
+   
+   Send a test email so you can see the effect.
+
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/emails-settings/email.png" width=915>
+
+When running your Test Suite/Test Suite Collection in console mode, you can also pass another value to override the default value of that Global Variable with the `-g_<variableName>=<variableValue>` syntax. For instance, `-g_<subject>=<Release 7.7>`.
 
 ## Network settings
 

--- a/pages/katalon-studio/docs/execution-settings.md
+++ b/pages/katalon-studio/docs/execution-settings.md
@@ -302,6 +302,20 @@ Where:
 * totalFailed: Total failed test cases
 * totalError: Total error test cases
 
+### Overriding Email Settings with Global Variables via Command line
+
+From **version 7.7 onwards**, you can override Email Settings with Global Variables via Command line. The below section guides you how to do that with a usage example.
+
+1. [Define a Global Variable](https://docs.katalon.com/katalon-studio/docs/execution-profile-v54.html#define-a-global-variable) in your Execution Profile.
+
+   <img src="">
+
+2. Parameterize that Global Variable in Email Settings by using the syntax `${GlobalVariable.name}` as a place holder in any supported locations including Sender, Recipients, Cc, Bcc, and Subject.
+   <img src="">
+
+3. Pass values to that Global Variable with the `-g_<variableName>=<variableValue>` syntax to override the Email Settings.
+   <img src="">
+
 ## Network settings
 
 ### Certificate settings

--- a/pages/katalon-studio/docs/import-openapi30.md
+++ b/pages/katalon-studio/docs/import-openapi30.md
@@ -1,0 +1,38 @@
+---
+title: "Import REST API with OpenAPI Specification 3.0" 
+sidebar: katalon_studio_docs_sidebar
+permalink: katalon-studio/docs/import-openapi30.html 
+---
+
+This manual shows you how to import RESTful APIs with [OpenAPI Specification version 3.0](https://swagger.io/specification/) to Katalon Studio. For OpenAPI 2.0 (Swagger), please see the following [document](https://docs.katalon.com/katalon-studio/docs/import-rest-requests-from-swagger-20.html).
+
+**Requirements**
+
+* Katalon Studio version 7.7+
+* An active Katalon Studio Enterprise license
+
+To import a service definition with OpenAPI 3.0, please do as follows:
+
+1. Open or create a project then import the service definition in two ways:
+
+* With a API/Web Service project type, click on the OpenAPI icon and select the **Import OpenAPI 3** option; or
+
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/import-openapi30/icon.png" width=351>
+
+* In **Tests Explorer**, right-click on any folder of **Object Repository** and select **Import > From OpenAPI 3**.
+
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/import-openapi30/rightclick.png" width=541>
+
+3. In the displayed dialog, browse your **OpenAPI 3.0** local file or enter an OpenAPI 3 URL, and click **OK**.
+
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/import-openapi30/browse.png" width=454>
+
+   Katalon Studio loads the file and generates RESTful test requests accordingly.
+
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/import-openapi30/imported.png" width=651>
+
+**See also:**
+
+* [Use test requests in a test case](https://docs.katalon.com/katalon-studio/docs/using-web-services-in-a-test-case.html)
+* [Parameterize a Web Service Object](/display/KD/Parameterize+a+Web+Service+Object)
+* [Verification Snippets](/display/KD/Verification+Snippets)

--- a/pages/katalon-studio/docs/import-rest-requests-from-swagger-20.md
+++ b/pages/katalon-studio/docs/import-rest-requests-from-swagger-20.md
@@ -1,5 +1,5 @@
 ---
-title: "Import REST requests from Swagger 2.0" 
+title: "Import RESTful requests with OpenAPI Specification 2.0 (Swagger)" 
 sidebar: katalon_studio_docs_sidebar
 permalink: katalon-studio/docs/import-rest-requests-from-swagger-20.html 
 redirect_from:

--- a/pages/katalon-studio/docs/import-selenium-ide.md
+++ b/pages/katalon-studio/docs/import-selenium-ide.md
@@ -13,7 +13,6 @@ This manual shows you how to import a Selenium IDE project to a project in Katal
 **Requirements**
 
 * Katalon Studio version 7.5.10 onwards
-* An active Katalon Studio Enterprise license
 
 ## Import a Selenium IDE project
 

--- a/pages/katalon-studio/docs/import-wadl.md
+++ b/pages/katalon-studio/docs/import-wadl.md
@@ -1,0 +1,31 @@
+---
+title: "Import RESTful requests from WADLs" 
+sidebar: katalon_studio_docs_sidebar
+permalink: katalon-studio/docs/import-wadl.html 
+---
+
+From **version 7.7+**, Katalon Studio supports importing [WADL](https://www.w3.org/Submission/2009/03/) files to create RESTful requests. This manual shows you how to import a WADL file into a Katalon project. You can use an example WADL Description provided [here](https://www.w3.org/Submission/wadl/#x3-40001.3).
+
+1. Open or create a project then import the service definition in two ways:
+
+* With a API/Web Service project type, click on the **Import WADL** icon; or
+
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/import-wadl/icon.png" width=302>
+
+* In **Tests Explorer**, right-click on any folder of **Object Repository** and select **Import > From WADL**
+
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/import-wadl/rightclick.png" width=589>
+
+2. In the displayed dialog, browse your **WADL** local file and click **OK**.
+
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/import-wadl/browse.png" width=399>
+
+   Katalon Studio loads the file and generates RESTful request objects accordingly.
+
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/import-wadl/imported.png" width=345>
+
+**See also:**
+
+* [Use test requests in a test case](https://docs.katalon.com/katalon-studio/docs/using-web-services-in-a-test-case.html)
+* [Parameterize a Web Service Object](/display/KD/Parameterize+a+Web+Service+Object)
+* [Verification Snippets](/display/KD/Verification+Snippets)

--- a/pages/katalon-studio/docs/introduction-to-desired-capabilities.md
+++ b/pages/katalon-studio/docs/introduction-to-desired-capabilities.md
@@ -189,15 +189,20 @@ The source code is available [here](https://github.com/katalon-studio/katalon-m
 * Define Desired Capabilities for execution on WinAppDriver of desktop applications testing.
 * **Project > Settings > Desired Capabilities > Windows**.
 
-> Starting in **Katalon Studio version 7.0**, Windows desktop application testing is available.
+> From **version 7.0 onwards**, Windows desktop application testing is available.
+> From **version 7.5 onwards**, Native Windows Recorder is available for Katalon Studio Enterprise users
 
-<img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/windows-desired-capabilities/desired-capa-win.png"  width="796" height="600">
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/windows-desired-capabilities/desired-capa-win.png"  width="796" height="600">
 
 These settings are applied for a test execution on a Windows desktop app. You are allowed to configure the WinAppDriver URL and Desired Capabilities for Windows to start a Windows Application Driver.
 
 * **WinAppDriver URL**: a URL to the WinAppDriver server. By default, Katalon Studio is set to http://127.0.0.1:4723.
 
-* **Desired Capabilities**: Katalon Studio supports the same [capabilities](https://github.com/microsoft/WinAppDriver/blob/master/Docs/AuthoringTestScripts.md#user-content-supported-locators-to-find-ui-elements) as WinAppDriver does.
+* **Desired Capabilities**: Katalon Studio supports the same [capabilities](https://github.com/microsoft/WinAppDriver/blob/master/Docs/AuthoringTestScripts.md#user-content-supported-locators-to-find-ui-elements) as WinAppDriver does. For Native Windows Recorder, only **appArguments** and **appWorkingDir** are supported. The below examples will show you how to use each of them in the Native Windows Recorder in a specific use case.
+
+### Example
+
+appArguments and appWorkingDir
 
 ## Remote Server
 

--- a/pages/katalon-studio/docs/introduction-to-desired-capabilities.md
+++ b/pages/katalon-studio/docs/introduction-to-desired-capabilities.md
@@ -189,20 +189,32 @@ The source code is available [here](https://github.com/katalon-studio/katalon-m
 * Define Desired Capabilities for execution on WinAppDriver of desktop applications testing.
 * **Project > Settings > Desired Capabilities > Windows**.
 
+> Change updates
+>
 > From **version 7.0 onwards**, Windows desktop application testing is available.
-> From **version 7.5 onwards**, Native Windows Recorder is available for Katalon Studio Enterprise users
+>
+> From **version 7.5 onwards**, Native Windows Recorder is available for Katalon Studio Enterprise users.
+> 
+> From **version 7.7 onwards**, Desired Capabilities for Native Windows Recorder are available.
 
    <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/windows-desired-capabilities/desired-capa-win.png"  width="796" height="600">
 
-These settings are applied for a test execution on a Windows desktop app. You are allowed to configure the WinAppDriver URL and Desired Capabilities for Windows to start a Windows Application Driver.
+These settings are applied to a test execution on a Windows desktop app. You are allowed to configure the WinAppDriver URL and Desired Capabilities for Windows to start a Windows Application Driver.
 
 * **WinAppDriver URL**: a URL to the WinAppDriver server. By default, Katalon Studio is set to http://127.0.0.1:4723.
+* **Desired Capabilities**: Katalon Studio supports the same [capabilities](https://github.com/microsoft/WinAppDriver/blob/master/Docs/AuthoringTestScripts.md#user-content-supported-locators-to-find-ui-elements) as WinAppDriver does. For Native Windows Recorder, only **appArguments** and **appWorkingDir** are supported (available in version 7.7).
+   * **appArguments**: Support passing arguments to the Application Under Test
+   * **appWorkingDir**: Support overriding the Application Under Test's working directory  
 
-* **Desired Capabilities**: Katalon Studio supports the same [capabilities](https://github.com/microsoft/WinAppDriver/blob/master/Docs/AuthoringTestScripts.md#user-content-supported-locators-to-find-ui-elements) as WinAppDriver does. For Native Windows Recorder, only **appArguments** and **appWorkingDir** are supported. The below examples will show you how to use each of them in the Native Windows Recorder in a specific use case.
+The example below shows you:
 
-### Example
+* The desired capabilities set for a Windows Application Under Test;
 
-appArguments and appWorkingDir
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/introduction-to-desired-capabilities/desired-capabilities.png">
+
+* How to use them in the Native Windows Recorder.
+
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/introduction-to-desired-capabilities/use-windows-capabilities.png">
 
 ## Remote Server
 

--- a/pages/katalon-studio/docs/introduction-to-web-services-test-object.md
+++ b/pages/katalon-studio/docs/introduction-to-web-services-test-object.md
@@ -10,17 +10,23 @@ redirect_from:
     - "/display/KD/Web+Service/"
 description:
 ---
-Katalon Studio v5.4 introduces all-new Web Services Testing for both RESTful and SOAP. Functionalities and UI have been enhanced to provide the following benefits:
+Katalon Studio supports API Testing with both RESTful and SOAP Services. You can import their definitions from different sources, create and test a single test request, or create functional test scripts. Below are some useful documentations for working with Web Service Requests:
 
-*   Details information regard to Web Services Request and its Response.
-*   Separate Request and Response section for more advanced Web Services Testing.
-*   Automatically add query parameters to REST object details based on its Request URL.
-*   Support various types related to Request information.
-*   Ability to format the content of Request and Response accordingly.
-*   [Ability to parameterize a Web Service object (Body, Header, URL)](/display/KD/Parameterize+a+Web+Service+object).
-*   [Builder to create and manage Web Service object easily in Script mode](/display/KD/Web+Services+Builder).
+### REST
 
-The below documentation have covered these great changes as well as updated guides for managing a Web Service object.
+[Create and design a RESTful Test Request](https://docs.katalon.com/katalon-studio/docs/restful.html). Or you can import Service definitions from:
 
-1.  [RESTful ](/katalon-studio/docs/restful)
-2.  [SOAP](/pages/viewpage.action?pageId=13697583)
+* [OpenAPI Specification 3.0](https://docs.katalon.com/katalon-studio/docs/import-openapi30.html) (Requirements: Version 7.7 onwards and Katalon Studio Enterprise license)
+* [WADLs](https://docs.katalon.com/katalon-studio/docs/import-wadl.html) (Required version: 7.7 onwards)
+* [SoapUI](https://docs.katalon.com/katalon-studio/docs/import-soapui.html) (Required version: 7.6 onwards)
+* [OpenAPI Specification 2.0 (Swagger)](https://docs.katalon.com/katalon-studio/docs/import-rest-requests-from-swagger-20.html)
+* [Postman](https://docs.katalon.com/katalon-studio/docs/import-postman.html)
+
+### SOAP
+
+[Create and design a SOAP Test Request](https://docs.katalon.com/katalon-studio/docs/soap.html). Or you can import Service definitions from [WSDLs](https://docs.katalon.com/katalon-studio/docs/import-soap-requests-from-wsdl.html).
+
+### Functionalities
+
+* [Builder to create and manage Web Service object easily in Script mode](/display/KD/Web+Services+Builder).
+* [Parameterize a Web Service object](https://docs.katalon.com/katalon-studio/docs/parameterize-a-web-service-object.html).

--- a/pages/katalon-studio/docs/record-web-utility.md
+++ b/pages/katalon-studio/docs/record-web-utility.md
@@ -22,7 +22,7 @@ description:
 ---
 Test recording is the easiest way for a tester to create an automation test script. This mean you just need to manually interact with your Web site and perform all the desired actions as a real user while the Katalon Recorder Utility record them.
 
-> In version 7.7+, Katalon supports validating UI elements during recording.
+> From **version 7.7+**, Katalon Studio supports adding Mouse Over and Verification steps by a right-click on an element in the AUT when recording with Chrome, Edge (Chromium-based), and Firefox.
 
 You can create a new test script or edit an existing test script by using the Katalon Recorder Utility. This manual includes a tutorial of how to record test scripts and a brief introduction to each panel of the Katalon Web Recorder.
 
@@ -54,21 +54,9 @@ To record a new test case, please do as follows:
    
    <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Screen-Shot-2018-06-27-at-10.05.19.png">
 
-7. Validate UI elements. 
+7. Stop recording and save your script. 
 
-   > From **version 7.7+**, Katalon supports adding Mouse Over and Verification Steps by a right-click on an element displayed in the AUT when recording with Chrome, Edge (Chromium-based), and Firefox.
-
-   Given that you enter incorrect username or password, you can validate if the website displays an error message indicating a failed login attempt.
-
-   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/validate-UI-elements.png">
-
-   Or you can verify if the next screen after a successful login is "right" by verifying if a specific UI element is present.
-
-   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Validate-2.png">
-    
-8. Stop recording and save your script. 
-
-   During your recording, Katalon captures the objects that you have interacted with. When saving test script, **Katalon Web Recorder** exports a list of objects used in the test case. Choose a directory you want your test objects to reside to continue.
+   During your recording, Katalon captures the objects that you have interacted with. When saving test script, **Katalon Web Recorder** exports a list of objects used in the test case. Choose a directory you want your test objects to reside to continue. 
 
 ## Record Using Existing Test Case
 
@@ -86,6 +74,31 @@ With the new Web Recorder, users can be more productive while modifying existing
 When saving your script, Katalon Studio automatically detects similar existing objects in **Objects Repository** and asks you for further action to optimize Object Repository.
 
 ![](https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/image2018-6-26-143A183A9.png)
+
+## Validate UI elements
+
+> From **version 7.7+**, Katalon supports adding Mouse Over and Verification Steps by a right-click on an element displayed in the AUT when recording with Chrome, Edge (Chromium-based), and Firefox.
+
+Given that you enter incorrect username or password, you can validate if the website displays an error message indicating a failed login attempt.
+
+<img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/validate-UI-elements.png">
+
+Or you can verify if the next screen after a successful login is "right" by verifying if a specific UI element is present.
+
+<img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Validate-2.png">
+
+In the drop-down list of the **Run** button, you can find some Run options. The two of them labeled with "Debug" are advanced options for validating recorded script, and saving you from running all test steps over and over again if you have a Katalon Studio Enterprise license:
+
+![](https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/tutorials/introduction-to-web-testing/77.png)
+ 
+* **Run all steps**: Execute ALL steps that are enabled on Web Recorder
+* **Debug: Run selected steps**: Execute only one or many selected steps. 
+
+   You can select multiple steps using either Ctrl or Shift key. The selected steps will be highlighted (e.g. steps #2, #6, #9 and #11 are selected for running).
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Screen-Shot-2018-06-27-at-11.45.48.png">
+
+* **Debug: Run from selected step**: Execute the currently selected step and all the steps after the selected one (e.g. run the test from step #4.
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Screen-Shot-2018-06-27-at-11.51.07.png"> 
 
 ## Katalon Web Recorder Utility's Components
 
@@ -107,20 +120,7 @@ In Katalon Web Recorder, you can manage the [variables](/x/RoIw) directly relate
 
 <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/var.png">
 
-### Test Execution and Logs
-
-In the drop-down list of the **Run** button, you can find some Run options. The two of them labeled with "Debug" are advanced options saving you from running all test steps over and over again if you have a Katalon Studio Enterprise license:
-
-![](https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/tutorials/introduction-to-web-testing/77.png)
- 
-* **Run all steps**: Execute ALL steps that are enabled on Web Recorder
-* **Debug: Run selected steps**: Execute only one or many selected steps. 
-
-   You can select multiple steps using either Ctrl or Shift key. The selected steps will be highlighted (e.g. steps #2, #6, #9 and #11 are selected for running).
-   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Screen-Shot-2018-06-27-at-11.45.48.png">
-
-* **Debug: Run from selected step**: Execute the currently selected step and all the steps after the selected one (e.g. run the test from step #4.
-   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Screen-Shot-2018-06-27-at-11.51.07.png">
+### Logs
 
 When running the recorded actions, you can investigate the execution by looking at its real-time detailed logs. Execution logs are displayed on the **Logs** tab.
 

--- a/pages/katalon-studio/docs/record-web-utility.md
+++ b/pages/katalon-studio/docs/record-web-utility.md
@@ -56,7 +56,7 @@ To record a new test case, please do as follows:
 
 7. Validate UI elements. 
 
-   > From **version 7.7+**, Katalon supports adding Mouse Over and Verification Steps by a right-click on an element displayed in the AUT.
+   > From **version 7.7+**, Katalon supports adding Mouse Over and Verification Steps by a right-click on an element displayed in the AUT when recording with Chrome, Edge (Chromium-based), and Firefox.
 
    Given that you enter incorrect username or password, you can validate if the website displays an error message indicating a failed login attempt.
 

--- a/pages/katalon-studio/docs/record-web-utility.md
+++ b/pages/katalon-studio/docs/record-web-utility.md
@@ -20,81 +20,113 @@ redirect_from:
     - "/katalon-studio/docs/record-web-utility-version-50-to-54.html"
 description: 
 ---
-Record
-------
+Test recording is the easiest way for a tester to create an automation test script. This mean you just need to manually interact with your Web site and perform all the desired actions as a real user while the Katalon Recorder Utility record them.
 
-### Record a New Test Case
+> In version 7.7+, Katalon supports validating UI elements during recording.
 
-* Without opening any test case, click on Web Record ![](https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Screen-Shot-2018-06-27-at-09.41.37.png) icon to open Web Recorder
-* Katalon Studio default browser is Chrome and the icon is displayed in the top right corner. You can change this default browser in **Project/Settings/Execution/Default execution**. You can also click on the drop-down button to select the browser you want to use:
+You can create a new test script or edit an existing test script by using the Katalon Recorder Utility. This manual includes a tutorial of how to record test scripts and a brief introduction to each panel of the Katalon Web Recorder.
 
-  ![](https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/edge-chromium.png)
+## Record a New Test Case
 
-  <table><thead><tr><th>Type</th><th>Description</th><th>Note</th></tr></thead><tbody><tr><td>New Browsers</td><td>Start a new browser</td><td><strong>Supported browsers:</strong><br>- Firefox<br>- Chrome<br>- Internet Explorer (only on Windows)<br>- Microsoft Edge (Chromium) (from version 7.5.10 onwards)</td></tr><tr><td>Active Browsers</td><td>Use the current browser (only Chrome)</td><td>Katalon Studio will install <a class="external-link" href="https://chrome.google.com/webstore/detail/katalon-recorder-selenium/ljdobmomdgdljniojadhoplhkpialdid" rel="nofollow">Katalon Recorder</a> as an add-on to help with recording for this type of browser<br><br><strong>Supported browsers:</strong><br>- Chrome<br>- Firefox</td></tr></tbody></table>
+To record a new test case, please do as follows:
 
-*   In this example, select either Chrome or Firefox from '**New Browser**' type to start recording.
+1. Click on the **Web Record Utility** ![](https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Screen-Shot-2018-06-27-at-09.41.37.png) icon to open the Web Recorder.
+
+2. Enter a URL of your web application. For example, https://katalon-demo-cura.herokuapp.com/
+
+3. Select a browser to start recording (either Chrome or Firefox from '**New Browser**' type is recommended). You can see the very first test step named "Open Browser" is recorded.
+
+   Katalon Studio's default browser is Chrome and its icon is displayed in the top right corner. If you prefer other supported browsers, you can change the default browser in **Project/Settings/Execution/Default execution**, or click on the drop-down button to select your preferred one: 
+
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/browser.png">
+
+    <table><thead><tr><th>Type</th><th>Description</th><th>Note</th></tr></thead><tbody><tr><td>New Browsers</td><td>Start a new browser</td><td><strong>Supported browsers:</strong><br>- Firefox<br>- Chrome<br>- Internet Explorer (only on Windows)<br>- Microsoft Edge (Chromium) (from version 7.5.10 onwards)</td></tr><tr><td>Active Browsers</td><td>Use the current browser (only Chrome)</td><td>Katalon Studio will install <a class="external-link" href="https://chrome.google.com/webstore/detail/katalon-recorder-selenium/ljdobmomdgdljniojadhoplhkpialdid" rel="nofollow">Katalon Recorder</a> as an add-on to help with recording for this type of browser<br><br><strong>Supported browsers:</strong><br>- Chrome<br>- Firefox</td></tr></tbody></table>
+
+4. A browser instance is launched automatically. Wait for your web page to load and interact with its elements.
+
+5. The browser highlights and displays its correspondent XPath (on the top of the page) when you hover that element.
+
+   > Tip: You can use hotkey to capture objects (pressing the combination of `<Alt + back quote>`). The captured object will be highlighted with a green border.
+
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/xpath.png">
+
+6. Interact with the web page. In this example, try signing in with the provided credentials. The recorded steps will be generated automatically in **Recorded Actions**. When you type in a **Password** field, Katalon Web Recorder uses '[Set Encrypted Text](/display/KD/%5BWebUI%5D+Set+Encrypted+Text)' keyword automatically. The input's value will be encrypted to ensure security.
+   
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Screen-Shot-2018-06-27-at-10.05.19.png">
+
+7. Validate UI elements. 
+
+   > From **version 7.7+**, Katalon supports adding Mouse Over and Verification Steps by a right-click on an element displayed in the AUT.
+
+   Given that you enter incorrect username or password, you can validate if the website displays an error message indicating a failed login attempt.
+
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/validate-UI-elements.png">
+
+   Or you can verify if the next screen after a successful login is "right" by verifying if a specific UI element is present.
+
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Validate-2.png">
     
-    > *   The browser will highlight and display its correspondent Xpath when you hover the mouse on that element.\
-    Notes: Starting from **Katalon Studio version 7.0**, a hotkey of Web Spy Utility is supported in Web Recorder to capture objects. Press the combination of `<Alt + back quote>` keys on the keyboard to capture object. The captured object will be highlighted with the green border.
-    > *   Recorded steps will generate in Recorded Actions.
-    > *   When you type in a Password field, Web Recorder will automatically use '[Set Encrypted Text](/display/KD/%5BWebUI%5D+Set+Encrypted+Text)' keyword and input's value will be encrypted to increase security.
-    > 
-    > ![](https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Screen-Shot-2018-06-27-at-10.05.19.png)
-    
+8. Stop recording and save your script. 
 
-### Record Using Existing Test Case
+   During your recording, Katalon captures the objects that you have interacted with. When saving test script, **Katalon Web Recorder** exports a list of objects used in the test case. Choose a directory you want your test objects to reside to continue.
+
+## Record Using Existing Test Case
 
 With the new Web Recorder, users can be more productive while modifying existing test cases. Instead of creating a brand new test case whenever there are changes to the UI, risks of overlooking how new changes might effect existing features are now minimized.
 
-*   Open any existing test case to continue recording.
-*   Click on **Record** icon to open Web Recorder.
-*   All existing test steps will be imported as Recorded Actions and current [Test Case variables](/display/KD/Variable+Types#VariableTypes-Localvariables) will be imported into the Variables tab in Web Recorder. You won't need to record the same test flow again.
+1. Open any existing test case to continue recording.
+2. Click on the **Record** icon to open Web Recorder.
+   
+   All the existing test steps and [Test Case variables](/display/KD/Variable+Types#VariableTypes-Localvariables) will be imported to the **Recorded Actions** and **Variables** tabs in Web Recorder respectively. You won't need to repeat the test steps having been recorded.
 
-![](https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Screen-Shot-2018-06-27-at-11.23.30.png)
+   ![](https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Screen-Shot-2018-06-27-at-11.23.30.png)
 
-Modify Recorded Actions
------------------------
+3. Interact with the AUT.
 
-Unlike previous Web Recorder's version, the list of available actions is the same with Katalon Studio [built-in keywords](/display/KD/Built-in+Keywords). You can add any action, call another test case, and/or use Custom Keywords.
-
-![](https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Screen-Shot-2018-06-27-at-11.30.37.png)
-
-Modify Recorded Objects
------------------------
-
-After you finish your recording, **Web Recorder** will export a list of test objects used in the test case. For more information on WebUI test objects, go [here](/x/tQTR).
-
-Upon satisfactorily creating your test case, click **OK** to add the recorded steps to the test case. Choose the directory you want your test objects to reside to continue. Here, Katalon Studio **automatically** **detects** similar **existing** objects in the Objects Repository and will ask you for further action. This helps users optimize object repositories.
+When saving your script, Katalon Studio automatically detects similar existing objects in **Objects Repository** and asks you for further action to optimize Object Repository.
 
 ![](https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/image2018-6-26-143A183A9.png)
 
-Variables
----------
+## Katalon Web Recorder Utility's Components
 
-In the new Web Recorder interface, you can manage the [variables](/x/RoIw) directly related to your recording.
+### Recorded Actions
 
-Execute
--------
+Available actions in Katalon Web Recorder Utility is the same as Katalon Studio's [built-in keywords](/display/KD/Built-in+Keywords). You can add any action, call another test case, and/or use Custom Keywords.
 
-Execution comes with seeing execution logs and, in many cases, you only want to execute some steps. New features have been introduced to prevent _having_ to execute all steps:
+![](https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Screen-Shot-2018-06-27-at-11.30.37.png)
 
-*   Logs: a real-time execution raw logs when you execute test steps.
-*   Run (with three types of run):
-    *   Run all steps
-    *   Debug: Run selected steps
-    *   Debug: Run from selected step
+### Captured Objects
 
-    > Note: You need a Katalon Studio Enterprise license to use this debugging feature in Katalon version 7.1+.
+During your recording, Katalon captures the objects that you have interacted with. When saving test script, **Katalon Web Recorder** exports a list of objects used in the test case. [Learn more about Web UI test objects](/x/tQTR).
 
-    ![](https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/tutorials/introduction-to-web-testing/77.png)
+<img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/captured-objects.png">
 
-<table><thead><tr><th>Type of Run</th><th>Description</th></tr></thead><tbody><tr><td>Run all steps</td><td>Execute ALL steps that are enabled on Web Recorder.</td></tr><tr><td>Debug: Run selected steps</td><td><p>Execute only one or many selected steps.</p><blockquote class="important"><p>You can select many steps using either Ctrl or Shift key from your keyword. Selected steps will be highlighted e.g run step #2, #6, #9 and #11 are selected.</p><p><img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Screen-Shot-2018-06-27-at-11.45.48.png"></p></blockquote></td></tr><tr><td>Debug: Run from selected step</td><td><p>Execute the current selected step and all steps after selected one, e.g run step #4 and all steps after it.</p><p><img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Screen-Shot-2018-06-27-at-11.51.07.png"></p></td></tr></tbody></table>
+### Variables
 
-Upon selecting any type of Run to execute, execution logs are displayed on Logs tab.
+In Katalon Web Recorder, you can manage the [variables](/x/RoIw) directly related to your recording.
+
+<img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/var.png">
+
+### Test Execution and Logs
+
+In the drop-down list of the **Run** button, you can find some Run options. The two of them labeled with "Debug" are advanced options saving you from running all test steps over and over again if you have a Katalon Studio Enterprise license:
+
+![](https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/tutorials/introduction-to-web-testing/77.png)
+ 
+* **Run all steps**: Execute ALL steps that are enabled on Web Recorder
+* **Debug: Run selected steps**: Execute only one or many selected steps. 
+
+   You can select multiple steps using either Ctrl or Shift key. The selected steps will be highlighted (e.g. steps #2, #6, #9 and #11 are selected for running).
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Screen-Shot-2018-06-27-at-11.45.48.png">
+
+* **Debug: Run from selected step**: Execute the currently selected step and all the steps after the selected one (e.g. run the test from step #4.
+   <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Screen-Shot-2018-06-27-at-11.51.07.png">
+
+When running the recorded actions, you can investigate the execution by looking at its real-time detailed logs. Execution logs are displayed on the **Logs** tab.
 
 ![](https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/record-web-utility/Screen-Shot-2018-06-27-at-11.54.27.png)
 
-> The steps above create and run a simple test case. For advanced features such as branching, looping or validation, you can refer to following articles: 
->
-> *   [Common Validation](https://www.katalon.com/tutorials/common-validation/) 
-> *   [Control Statements](/display/KD/Control+Statements)
+For advanced features such as branching, looping or validation, you can refer to following articles: 
+
+* [Common Validation](https://www.katalon.com/tutorials/common-validation/) 
+* [Control Statements](/display/KD/Control+Statements)

--- a/pages/katalon-studio/docs/use-online-license.md
+++ b/pages/katalon-studio/docs/use-online-license.md
@@ -37,7 +37,10 @@ All users of an organization can use RE online licenses as long as the total num
 To run Katalon Studio or Katalon Studio Enterprise with Katalon Runtime Engine, you need to:
 
 1. Log in to your Katalon account on Katalon Studio.
-2. In the command generator, generate a command with the auto-filled Katalon API Key and customized information.
+2. In the command generator, generate a command with the auto-filled Katalon API Key and customized information. 
+
+   From **version 7.7 onwards**, if you belong to more than one Organization subscribing to RE licenses, you can choose which one to validate your license usage. Katalon retrieves and displays the organizations binding to your Katalon account and having RE licenses. Once selected, the Organization ID is passed to the generated command (`-orgID=<Katalon_OrgID>`).
+
 3. Copy and paste the generated command into **Terminal** (for macOS/Linux) or **Command Prompt** (for Windows).
 4. Open the command prompt and navigate to the folder of Katalon Studio Engine: `katalonc.exe` (Windows), Applications folder (Mac OS), or `katalonc` (Linux) file.
 
@@ -49,7 +52,7 @@ To run Katalon Studio or Katalon Studio Enterprise with Katalon Runtime Engine, 
 
 5. Enter the following syntax to execute automation test:
 
-    For example: `katalonc -noSplash -runMode=console -consoleLog -noExit -projectPath="C:\Users\Katalon Studio\Project\YourProject.prj" -retry=0 -testSuitePath="Test Suites/TS_RegressionTest" -browserType="Chrome (headless)" -apiKey=abczxzxz`
+    For example: `katalonc -noSplash -runMode=console -consoleLog -noExit -projectPath="C:\Users\Katalon Studio\Project\YourProject.prj" -retry=0 -testSuitePath="Test Suites/TS_RegressionTest" -browserType="Chrome (headless)" -apiKey=abczxzxz -orgID=123xx`
 
     > [Katalon API Key](https://docs.katalon.com/katalon-analytics/docs/ka-api-key.html#create-an-api-key) is required for activating RE.
     >

--- a/pages/katalon-studio/new/version-70.md
+++ b/pages/katalon-studio/new/version-70.md
@@ -24,7 +24,7 @@ description: Release note 7.x
 * [Katalon Studio Enterprise - Web Service Testing] Import Open API 3.0. [Learn more](https://docs.katalon.com/import-openapi30.html)
 * [Web Service Testing] Import WADL. [Learn more](https://docs.katalon.com/import-wadl.html)
 * [Windows Testing] Support passing Capabilities including `appArguments` and `appWorkingDir` for Native Windows Recorder. [Learn more](https://docs.katalon.com/katalon-studio/docs/introduction-to-desired-capabilities.html#windows-desktop-app-testing)
-* [Katalon Runtime Engine] Allow overriding Email settings with Global Variables in command-line execution. [Learn more](https://docs.katalon.com/)
+* [Katalon Runtime Engine] Allow overriding Email settings with Global Variables via command line. [Learn more](https://docs.katalon.com/katalon-studio/docs/execution-settings.html#Overriding-email-settings-with-global-variables-via-command-line)
 * [Katalon Runtime Engine] Allow selecting an Organization for license validation when activating Katalon Runtime Engine. [Learn more](https://docs.katalon.com/katalon-studio/docs/use-online-license.html#katalon-runtime-engine)
 * [Katalon TestOps (Beta) Integration] Support integration with Katalon TestOps Vision for visual testing. [Learn more](https://forum.katalon.com/t/early-release-of-katalon-testops-vision-visual-testing-image-comparison)
 

--- a/pages/katalon-studio/new/version-70.md
+++ b/pages/katalon-studio/new/version-70.md
@@ -20,23 +20,24 @@ description: Release note 7.x
 
 ### New features
 
-* [Katalon Record Utitlity] Adding verification steps via direct interaction in Chrome, Edge (Chromium based), and Firefox. [Learn more](https://docs.katalon.com/)
-* [Katalon Studio Enterprise - Web Service Testing] Import Open API 3.0. [Learn more](https://docs.katalon.com/)
-* [Web Service Testing] Import WADL. [Learn more](https://docs.katalon.com/)
-* [Windows Testing] Native Windows Recorder: Pass arguments to executable in Windows Recorder. [Learn more](https://docs.katalon.com/)
-* [Katalon Runtime Engine] Allow overriding Email settings in command line via Global Variable. [Learn more](https://docs.katalon.com/)
-* [Katalon Runtime Engine] Allow selecting an Organization for checking KRE license in Command Generator. [Learn more](https://docs.katalon.com/)
+* [Katalon Record Utility] Support adding verification test steps during recording with Chrome, Edge (Chromium-based), and Firefox. [Learn more](https://docs.katalon.com/katalon-studio/docs/record-web-utility.html)
+* [Katalon Studio Enterprise - Web Service Testing] Import Open API 3.0. [Learn more](https://docs.katalon.com/import-openapi30.html)
+* [Web Service Testing] Import WADL. [Learn more](https://docs.katalon.com/import-wadl.html)
+* [Windows Testing] Support passing Capabilities including `appArguments` and `appWorkingDir` for Native Windows Recorder. [Learn more](https://docs.katalon.com/katalon-studio/docs/introduction-to-desired-capabilities.html#windows-desktop-app-testing)
+* [Katalon Runtime Engine] Allow overriding Email settings with Global Variables in command-line execution. [Learn more](https://docs.katalon.com/)
+* [Katalon Runtime Engine] Allow selecting an Organization for license validation when activating Katalon Runtime Engine. [Learn more](https://docs.katalon.com/katalon-studio/docs/use-online-license.html#katalon-runtime-engine)
+* [Katalon TestOps (Beta) Integration] Support integration with Katalon TestOps Vision for visual testing. [Learn more](https://forum.katalon.com/t/early-release-of-katalon-testops-vision-visual-testing-image-comparison)
 
 ### Improvements
 
-* Install Basic Reports plugin automatically for all users
-* API docs version 7.7
+* Install the Basic Reports plugin automatically for all users
+* Publish [API docs version 7.7](https://docs.katalon.com/javadoc/index.html)
 
 ### Fixes
 
-* Bug: [Web Recorder] Objects cannot be found when running a script after recording it with option 'Merge objects', 'Duplicate objects', or 'Replace existing objects'
-* Bug: TestOps Integration: Cannot display more than 20 projects fetched from TestOps
-* Bug: [TestNG] Incorrect return step status of Run JUnit classes keyword
+* Bug: [Katalon Record Utility] Unable to locate Objects during execution if the objects are captured with such options as **Merge objects**, **Duplicate objects**, or **Replace existing objects**
+* Bug: [Katalon TestOps (Beta) Integration]: Cannot display more than 20 projects fetched from Katalon TestOps
+* Bug: [TestNG] Return incorrect test results when using the `runTestNGTestClasses` keyword
 
 ## Official Release - Version 7.6.6
 

--- a/pages/katalon-studio/new/version-70.md
+++ b/pages/katalon-studio/new/version-70.md
@@ -30,13 +30,15 @@ description: Release note 7.x
 
 ### Improvements
 
+* Support Microsoft Edge (Chromium) 85
+* Support Chrome 85
 * Install the Basic Reports plugin automatically for all users
 * Publish [API docs version 7.7](https://docs.katalon.com/javadoc/index.html)
 
 ### Fixes
 
 * Bug: [Katalon Record Utility] Unable to locate Objects during execution if the objects are captured with such options as **Merge objects**, **Duplicate objects**, or **Replace existing objects**
-* Bug: [Katalon TestOps (Beta) Integration]: Cannot display more than 20 projects fetched from Katalon TestOps (Beta)
+* Bug: [Katalon TestOps (Beta) Integration]: Cannot display more than 20 projects fetched from Katalon TestOps (Beta)
 * Bug: [TestNG] Return incorrect test results when using the `runTestNGTestClasses` keyword
 
 ## Version 7.6.6

--- a/pages/katalon-studio/new/version-70.md
+++ b/pages/katalon-studio/new/version-70.md
@@ -24,7 +24,7 @@ description: Release note 7.x
 * [Katalon Studio Enterprise - Web Service Testing] Import Open API 3.0. [Learn more](https://docs.katalon.com/import-openapi30.html)
 * [Web Service Testing] Import WADL. [Learn more](https://docs.katalon.com/import-wadl.html)
 * [Windows Testing] Support passing Capabilities including `appArguments` and `appWorkingDir` for Native Windows Recorder. [Learn more](https://docs.katalon.com/katalon-studio/docs/introduction-to-desired-capabilities.html#windows-desktop-app-testing)
-* [Katalon Runtime Engine] Allow overriding Email settings with Global Variables via command line. [Learn more](https://docs.katalon.com/katalon-studio/docs/execution-settings.html#Overriding-email-settings-with-global-variables-via-command-line)
+* Support using Global Variables in Email Settings. [Learn more](https://docs.katalon.com/katalon-studio/docs/execution-settings.html#support-global-variables-in-email-settings)
 * [Katalon Runtime Engine] Allow selecting an Organization for license validation when activating Katalon Runtime Engine. [Learn more](https://docs.katalon.com/katalon-studio/docs/use-online-license.html#katalon-runtime-engine)
 * [Katalon TestOps (Beta) Integration] Support integration with Katalon TestOps Vision for visual testing. [Learn more](https://forum.katalon.com/t/early-release-of-katalon-testops-vision-visual-testing-image-comparison)
 

--- a/pages/katalon-studio/new/version-70.md
+++ b/pages/katalon-studio/new/version-70.md
@@ -16,6 +16,27 @@ redirect_from:
     - "/katalon-studio/new/version-501.html"
 description: Release note 7.x
 ---
+## Pre-Release - Version 7.7
+
+### New features
+
+* [Katalon Record Utitlity] Adding verification steps via direct interaction in Chrome, Edge (Chromium based), and Firefox. [Learn more](https://docs.katalon.com/)
+* [Katalon Studio Enterprise - Web Service Testing] Import Open API 3.0. [Learn more](https://docs.katalon.com/)
+* [Web Service Testing] Import WADL. [Learn more](https://docs.katalon.com/)
+* [Windows Testing] Native Windows Recorder: Pass arguments to executable in Windows Recorder. [Learn more](https://docs.katalon.com/)
+* [Katalon Runtime Engine] Allow overriding Email settings in command line via Global Variable. [Learn more](https://docs.katalon.com/)
+* [Katalon Runtime Engine] Allow selecting an Organization for checking KRE license in Command Generator. [Learn more](https://docs.katalon.com/)
+
+### Improvements
+
+* Install Basic Reports plugin automatically for all users
+* API docs version 7.7
+
+### Fixes
+
+* Bug: [Web Recorder] Objects cannot be found when running a script after recording it with option 'Merge objects', 'Duplicate objects', or 'Replace existing objects'
+* Bug: TestOps Integration: Cannot display more than 20 projects fetched from TestOps
+* Bug: [TestNG] Incorrect return step status of Run JUnit classes keyword
 
 ## Official Release - Version 7.6.6
 
@@ -98,7 +119,7 @@ You can download Katalon Studio version 7.6.5 [here](https://github.com/katalon-
 
 ### New feature
 
-* [Katalon Studio Enterprise] Support importing test scripts of Selenium IDE version 3.x. [Learn more](https://docs.katalon.com/katalon-studio/docs/import-selenium-ide.html)
+* Support importing test scripts of Selenium IDE version 3.x. [Learn more](https://docs.katalon.com/katalon-studio/docs/import-selenium-ide.html)
 
 ### Improvement
 

--- a/pages/katalon-studio/new/version-70.md
+++ b/pages/katalon-studio/new/version-70.md
@@ -20,7 +20,7 @@ description: Release note 7.x
 
 ### New features
 
-* [Katalon Record Utility] Support adding verification test steps during recording with Chrome, Edge (Chromium-based), and Firefox. [Learn more](https://docs.katalon.com/katalon-studio/docs/record-web-utility.html)
+* [Katalon Record Utility] Support adding verification test steps during recording with Chrome, Edge (Chromium-based), and Firefox. [Learn more](https://docs.katalon.com/katalon-studio/docs/record-web-utility.html#validate-ui-elements).
 * [Katalon Studio Enterprise - Web Service Testing] Import Open API 3.0. [Learn more](https://docs.katalon.com/import-openapi30.html)
 * [Web Service Testing] Import WADL. [Learn more](https://docs.katalon.com/import-wadl.html)
 * [Windows Testing] Support passing Capabilities including `appArguments` and `appWorkingDir` for Native Windows Recorder. [Learn more](https://docs.katalon.com/katalon-studio/docs/introduction-to-desired-capabilities.html#windows-desktop-app-testing)

--- a/pages/katalon-studio/new/version-70.md
+++ b/pages/katalon-studio/new/version-70.md
@@ -16,7 +16,7 @@ redirect_from:
     - "/katalon-studio/new/version-501.html"
 description: Release note 7.x
 ---
-## Pre-Release - Version 7.7
+## Official Release - Version 7.7
 
 ### New features
 
@@ -36,10 +36,10 @@ description: Release note 7.x
 ### Fixes
 
 * Bug: [Katalon Record Utility] Unable to locate Objects during execution if the objects are captured with such options as **Merge objects**, **Duplicate objects**, or **Replace existing objects**
-* Bug: [Katalon TestOps (Beta) Integration]: Cannot display more than 20 projects fetched from Katalon TestOps
+* Bug: [Katalon TestOps (Beta) Integration]: Cannot display more than 20 projects fetched from Katalon TestOps (Beta)
 * Bug: [TestNG] Return incorrect test results when using the `runTestNGTestClasses` keyword
 
-## Official Release - Version 7.6.6
+## Version 7.6.6
 
 ### Improvements
 


### PR DESCRIPTION
- [x] [Katalon Record Utitlity] Adding verification steps via direct interaction in Chrome, Edge (Chromium-based), and Firefox. 

- [x]  Import Open API 3.0. 

- [x]  Import WADL. 

- [x] [Windows Testing] Support passing Capabilities including `appArguments` and `appWorkingDir` for Native Windows Recorder. 

- [x] Allow using Global Variables in Email settings. 

- [x] [Katalon Runtime Engine] Allow selecting an Organization for checking KRE license in Command Generator. Learn more

- [x] 7 Keywords