### PR TITLE
Fix typo in Create Your First Plugin tutorial sample code

### DIFF
--- a/pages/katalon-store/docs/publisher/create-plugin.md
+++ b/pages/katalon-store/docs/publisher/create-plugin.md
@@ -179,7 +179,7 @@ To extend this extension point, we need to declare in `plugin.xml` as shown belo
 	    <point
 	          id="com.mycompany.plugin.myFirstExtensionId"
 	          extensionPointId="com.katalon.platform.api.extension.pluginActivationListener"
-	          implementationClass="com.mycompany.plugin.MyPluginActivationListener"
+	          implementationClass="com.mycompany.plugin.MyPluginActivationListener">
 	    </point>
 	</extension>
 </plugin>


### PR DESCRIPTION
There is a typo in sample code provided for plugin.xml in the create plugin tutorial. There is no ">" closing the point tag at the end of the implementationClass line. This causes the plugin to not work correctly when you test it in step 6.