### PR TITLE
Update katalon_studio_docs_sidebar.yml

### DIFF
--- a/_data/sidebars/katalon_studio_docs_sidebar.yml
+++ b/_data/sidebars/katalon_studio_docs_sidebar.yml
@@ -1329,8 +1329,6 @@ items:
                 url: /katalon-analytics/docs/create-plan.html
               - title: "Execute Test Runs by a Trigger"
                 url: /katalon-analytics/docs/kt-scheduler.html
-              - title: "Execute Test Runs manually"
-                url: /katalon-analytics/docs/execute-test-run.html
               - title: "View Test Plan Summary in Katalon Studio"
                 url: /katalon-analytics/docs/view-ci-plans.html
           - title: "Releases"


### PR DESCRIPTION
delete 'execute test runs manually' sidebar. redirect link is added in this [PR](https://github.com/katalon-studio/docs/pull/1174)