### PR TITLE
K1 license update

### DIFF
--- a/pages/katalon-studio/docs/license.md
+++ b/pages/katalon-studio/docs/license.md
@@ -35,7 +35,7 @@ There are two types of licenses for KSE and KRE: node-locked and floating. Depen
 			<td>
 				<p>One license is assigned to one machine ID.</p>
 			</td>
-			<td>One license is assigned to one execution session and can be shared between 3 machines.</td>
+			<td>One license is assigned to one execution session and can be shared across multiple accounts.</td>
 		</tr>
 		<tr>
 			<td>

--- a/pages/katalon-studio/docs/license.md
+++ b/pages/katalon-studio/docs/license.md
@@ -35,13 +35,13 @@ There are two types of licenses for KSE and KRE: node-locked and floating. Depen
 			<td>
 				<p>One license is assigned to one machine ID.</p>
 			</td>
-			<td>One license is assigned to one execution session and can be shared across multiple accounts.</td>
+			<td>One license is assigned to one execution session and can be shared across multiple machines.</td>
 		</tr>
 		<tr>
 			<td>
 				<p>Licenses are transferable.</p>
 			</td>
-			<td>Licenses need to be assigned.</td>
+			<td>Licenses are transferable.</td>
 		</tr>
 		<tr>
 			<td>
@@ -85,9 +85,9 @@ For scaling teams with dynamic usage, floating licenses reduce the management co
 
 This license type is applied to all types of execution environments, including cloud or virtual machines with dynamic hardware specifications (to execute tests in Docker, Azure, AWS).
 
-* One floating license can be shared across a maximum of 3 machines.
+* One floating license can be shared across multiple machines.
 * One floating license is assigned to one execution session at a time.
 
 For instance, you have 1 floating Katalon Studio Enterprise license attached to the email example@katalon.com.
 
-You can use example@katalon.com to log in to Katalon Studio on up to 3 different machines, but not at the same time. This is because  example@katalon.com represents only 1 floating Katalon Studio Enterprise license. Therefore, you can only be active on 1 of those 3 machines at a time.
+You can use example@katalon.com to log in to Katalon Studio on multiple different machines, but not at the same time. This is because  example@katalon.com represents only 1 floating Katalon Studio Enterprise license. Therefore, you can only be active on 1 of those machines at a time.

--- a/pages/katalon-studio/docs/license.md
+++ b/pages/katalon-studio/docs/license.md
@@ -13,7 +13,7 @@ This section provides information on the licensing system of Katalon. You will f
 
 Katalon Studio provides free, basic tools suitable for the testing needs of individuals. For an advanced business solution, consider purchasing Katalon Studio Enterprise licenses. For feature comparison between KS and KSE, see [Katalon Studio vs Katalon Studio Enterprise Features](https://docs.katalon.com/katalon-studio/docs/katalon-studio-vs-katalon-studio-enterprise.html).
 
-Licenses are transferable. You need an internet connection to activate and validate licenses, although special rules apply to enable offline activation. See: [Create an offline license](https://docs.katalon.com/katalon-studio/docs/use-online-license.html#create-an-offline-license).
+One KSE license can be activated and used on one machine at a time. Licenses are transferable. You need an internet connection to activate and validate licenses, although special rules apply to enable offline activation. See: [Create an offline license](https://docs.katalon.com/katalon-studio/docs/use-online-license.html#create-an-offline-license).
 
 ## Katalon Runtime Engine
 

--- a/pages/katalon-studio/docs/license.md
+++ b/pages/katalon-studio/docs/license.md
@@ -13,7 +13,7 @@ This section provides information on the licensing system of Katalon. You will f
 
 Katalon Studio provides free, basic tools suitable for the testing needs of individuals. For an advanced business solution, consider purchasing Katalon Studio Enterprise licenses. For feature comparison between KS and KSE, see [Katalon Studio vs Katalon Studio Enterprise Features](https://docs.katalon.com/katalon-studio/docs/katalon-studio-vs-katalon-studio-enterprise.html).
 
-One KSE license is exclusively assigned to one Katalon account and can be activated/used on one machine at a time. Licenses are transferable. You need an internet connection to activate and validate licenses, although special rules apply to enable offline activation. See: [Create an offline license](https://docs.katalon.com/katalon-studio/docs/use-online-license.html#create#an#offline#license).
+Licenses are transferable. You need an internet connection to activate and validate licenses, although special rules apply to enable offline activation. See: [Create an offline license](https://docs.katalon.com/katalon-studio/docs/use-online-license.html#create-an-offline-license).
 
 ## Katalon Runtime Engine
 
@@ -77,7 +77,6 @@ With node-locked licenses, one machine running tests = one license.
 * A machine can be mapped to multiple licenses if needed.
 * For machines connected to the internet, the licenses can be transferred to other machines at no cost and as many times as needed.
 * For _annual licenses_ only: Licenses can be converted to be used in an offline environment. Once converted, the license cannot be transferred to another machine until it is expired.
-* Licenses purchased on a monthly basis cannot be converted for use in an offline environment.
 
 ### Floating License
 

--- a/pages/katalon-studio/docs/use-online-license.md
+++ b/pages/katalon-studio/docs/use-online-license.md
@@ -63,7 +63,7 @@ Your users can now activate their KSE and KRE licenses. You can refer them to th
 
 Granting a license this way allows you to transfer a license freely among registered users of an Organization as long as the number of licensed users does not exceed the license quota.
 
-You can revoke these licenses at any time by following this guide: [Manage Katalon Licenses](https://docs.katalon.com/katalon-studio/docs/license-management.html).
+You can revoke these licenses at any time by following this guide: [Manage Katalon Licenses](https://docs.katalon.com/katalon-studio/docs/license-management.html#revoke-and-transfer-a-license).
 
 If the users you wish to grant a license to are not connected to the internet, you can instead generate an offline license.
 
@@ -124,5 +124,5 @@ Follow these steps:
 8. Send your users this activation guide: [Activate Katalon License](https://docs.katalon.com/katalon-studio/docs/activate-license.html).
 
 See also:
-* [Manage Katalon Licenses](https://docs.katalon.com/katalon-studio/docs/license-utilization-dashboard.html#license-usage-visualization).
+* [Manage Katalon Licenses](https://docs.katalon.com/katalon-studio/docs/license-management.html).
 * [License Utilization Dashboard](https://docs.katalon.com/katalon-studio/docs/license-utilization-dashboard.html#license-usage-visualization).

--- a/pages/katalon-studio/docs/use-online-license.md
+++ b/pages/katalon-studio/docs/use-online-license.md
@@ -38,9 +38,9 @@ Follow these steps to grant KSE licenses:
 
   You have granted the KSE licenses to your users.
 
-For KRE, all members of your Organization can use the KRE licenses by default once the Organization has purchased **only one type of license (node-locked or floating) at a time**.
+For KRE, all members of your Organization can use the KRE licenses by default if your Organization has purchased only one type of license, either node-locked or floating.
 
-If your Organization has purchased two types of license at the same time. All members of your Organization can use the KRE node-locked licenses by default. However, to use the KRE floating licenses, you have to assign the license to your users by following these steps:
+If your Organization has purchased both types of licenses at the same time, all members of your Organization can use the KRE node-locked licenses by default. However, to use the KRE floating licenses, you have to assign the license to your users by following these steps:
 
 1. Sign in to [Katalon TestOps](https://testops.katalon.io/login), select your Organization, then go to **Settings** > **License Management**.
 

--- a/pages/katalon-studio/docs/use-online-license.md
+++ b/pages/katalon-studio/docs/use-online-license.md
@@ -107,7 +107,9 @@ Follow these steps:
 
 5. Enter the User's machine ID and input the expiry date, then click **Create**.
 
-    <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/license-mgt/create-offline-license-page.png" width="1424" height="" alt="create offline license page">
+    <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/license-mgt/create-offline-license-kse.png" width="1424" height="" alt="create offline license page">
+
+    You can also add a note on the offline license in the **Description** section.
 
   > Notes:
   >

--- a/pages/katalon-studio/docs/use-online-license.md
+++ b/pages/katalon-studio/docs/use-online-license.md
@@ -36,16 +36,28 @@ Follow these steps to grant KSE licenses:
   
 3. Add users to the **Licensed Users** section.
 
-  You have granted the KSE licenses to Users.
+  You have granted the KSE licenses to your users.
 
-For KRE, all Users of an Organization can use the KRE licenses by default once the Organization has purchased the KRE licenses.
+For KRE, all members of your Organization can use the KRE licenses by default once the Organization has purchased **only one type of license (node-locked or floating) at a time**.
 
-However, to optimize license usage and avoid session termination, the Owner and Admin must remember the following rules:
+If your Organization has purchased two types of license at the same time. All Members of your Organization can use the KRE node-locked licenses by default. However, to use the KRE floating licenses, you have to assign the license to your users by following these steps:
 
-* Each session accounts for one license.
-* The number of parallel sessions cannot exceed the license quota.
-* The number of registered machine IDs cannot exceed the license quota. You can remove a registered machine ID by following this guide: [Manage Katalon Licenses](https://docs.katalon.com/katalon-studio/docs/license-management.html#revoke-a-license).
-* Users need [API Keys](https://docs.katalon.com/katalon-studio/docs/katalon-apikey-70.html) to activate a KRE online license.
+1. Sign in to [Katalon TestOps](https://testops.katalon.io/login), select your Organization, then go to **Settings** > **License Management**.
+
+    The **Licenses** page appears.
+
+2. Choose KRE (Floating).
+3. Add users to the **Licensed Users** section.
+
+  You have granted the KRE floating licenses to your users.
+
+> Notes:
+>
+> To optimize license usage and avoid session termination, the Owner and Admin must remember the following rules:
+>
+> * Each session accounts for one license.
+> * The number of parallel sessions cannot exceed the license quota.
+> * Users need [API Keys](https://docs.katalon.com/katalon-studio/docs/katalon-apikey-70.html) to activate a KRE online license.
 
 Your users can now activate their KSE and KRE licenses. You can refer them to this link for activation: [Activate Katalon License](https://docs.katalon.com/katalon-studio/docs/activate-license.html).
 

--- a/pages/katalon-studio/docs/use-online-license.md
+++ b/pages/katalon-studio/docs/use-online-license.md
@@ -38,6 +38,11 @@ Follow these steps to grant KSE licenses:
 
   You have granted the KSE licenses to your users.
 
+> Notes:
+>
+> * For KSE node-locked licenses, the number of assigned users cannot exceed the license quota.
+> * For KSE floating licenses, there is no limit on the number of assigned users.
+
 For KRE, all members of your Organization can use the KRE licenses by default if your Organization has purchased only one type of license, either node-locked or floating.
 
 If your Organization has purchased both types of licenses at the same time, all members of your Organization can use the KRE node-locked licenses by default. However, to use the KRE floating licenses, you have to assign the license to your users by following these steps:
@@ -53,7 +58,7 @@ If your Organization has purchased both types of licenses at the same time, all 
 
 > Notes:
 >
-> To optimize license usage and avoid session termination, the Owner and Admin must remember the following rules:
+> For both KRE node-locked and floating licenses, there is no limit on the number of assigned users. However, to optimize license usage and avoid session termination, the Owner and Admin must remember the following rules:
 >
 > * Each session accounts for one license.
 > * The number of parallel sessions cannot exceed the license quota.

--- a/pages/katalon-studio/docs/use-online-license.md
+++ b/pages/katalon-studio/docs/use-online-license.md
@@ -112,8 +112,8 @@ Follow these steps:
 
 5. Enter the User's machine ID and input the expiry date, then click **Create**.
 
-    <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/license-mgt/create-offline-license-kse.png" width="1424" height="" alt="create offline license page">
-
+    <img src="https://github.com/katalon-studio/docs-images/raw/master/katalon-studio/docs/license-mgt/create-offline-license-kse.png" width=100% alt="create offline license page">
+    
     You can also add a note on the offline license in the **Description** section.
 
   > Notes:

--- a/pages/katalon-studio/docs/use-online-license.md
+++ b/pages/katalon-studio/docs/use-online-license.md
@@ -32,7 +32,7 @@ Follow these steps to grant KSE licenses:
 
   > Notes:
   >
-  > See [Types of Licenses](https://docs.katalon.com/katalon-studio/docs/overview.html#types#of#licenses) to understand the differences between a node-locked license and a floating license.
+  > See [Types of Licenses](https://docs.katalon.com/katalon-studio/docs/license.html#license-types) to understand the differences between a node-locked license and a floating license.
   
 3. Add users to the **Licensed Users** section.
 

--- a/pages/katalon-studio/docs/use-online-license.md
+++ b/pages/katalon-studio/docs/use-online-license.md
@@ -40,7 +40,7 @@ Follow these steps to grant KSE licenses:
 
 For KRE, all members of your Organization can use the KRE licenses by default once the Organization has purchased **only one type of license (node-locked or floating) at a time**.
 
-If your Organization has purchased two types of license at the same time. All Members of your Organization can use the KRE node-locked licenses by default. However, to use the KRE floating licenses, you have to assign the license to your users by following these steps:
+If your Organization has purchased two types of license at the same time. All members of your Organization can use the KRE node-locked licenses by default. However, to use the KRE floating licenses, you have to assign the license to your users by following these steps:
 
 1. Sign in to [Katalon TestOps](https://testops.katalon.io/login), select your Organization, then go to **Settings** > **License Management**.
 


### PR DESCRIPTION
[sprint02 ticket](https://katalon.atlassian.net/browse/TDAP-180). Updates: removed 3 accounts limit for floating licenses, added more details on granting KRE licenses and changed new UI screenshot following K1's input